### PR TITLE
Using method instead of config variable for incoming_url

### DIFF
--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -51,7 +51,7 @@ module Lita
 			def http_post(payload)
 				res = Faraday.post do |req|
 					log.debug "Slack::http_post sending payload to #{incoming_url}; length: #{payload.to_json.size}"
-					req.url config.incoming_url, :token => config.incoming_token
+					req.url incoming_url, :token => config.incoming_token
 					req.headers['Content-Type'] = 'application/json'
 					req.body = payload.to_json
 				end


### PR DESCRIPTION
config.incoming_url was nil as I only defined team_name and relied on lira-slack to generate correct URL properly. Fixed that URL to send messages is now using method to create incoming_url.
