### PR TITLE
Add SQS listener in adapter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem 'aws-sdk'

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -3,73 +3,81 @@ require 'faraday'
 require 'json'
 
 module Lita
-	module Adapters
-		class Slack < Adapter
-			# Required Lita config keys (via lita_config.rb)
-			require_configs :incoming_token, :team_domain
+  module Adapters
+    class Slack < Adapter
+      # Required Lita config keys (via lita_config.rb)
+      require_configs :incoming_token, :team_domain
 
-			# Adapter main run loop
-			def run
-				log.debug 'Slack::run started'
-				sleep
-				rescue Interrupt
-				shut_down
-			end
+      # Adapter main run loop
+      def run
+        listen_to_sqs
+        log.debug 'Slack::run started'
+        sleep
+      rescue Interrupt
+        shut_down
+      end
 
-			def send_messages(target, strings)
-				log.debug 'Slack::send_messages started'
-				status = http_post prepare_payload(target, strings)
-				log.error "Slack::send_messages failed to send (#{status})" if status != 200
-				log.debug 'Slack::send_messages ending'
-			end
+      def send_messages(target, strings)
+        log.debug 'Slack::send_messages started'
+        status = http_post prepare_payload(target, strings)
+        log.error "Slack::send_messages failed to send (#{status})" if status != 200
+        log.debug 'Slack::send_messages ending'
+      end
 
-			def set_topic(target, topic)
-				# Slack currently provides no method
-				log.info 'Slack::set_topic no implementation'
-			end
+      def set_topic(target, topic)
+        # Slack currently provides no method
+        log.info 'Slack::set_topic no implementation'
+      end
 
-			def shut_down
-			end
+      def shut_down
+      end
 
       private
 
-			def prepare_payload(target, strings)
-				if not defined?(target.room)
-					channel_id = nil
-					log.warn "Slack::prepare_payload proceeding without channel designation"
-				else
-					channel_id = target.room
-				end
-				payload = {'channel' => channel_id, 'username' => username}
-				payload['text'] = strings.join('\n')
-				if add_mention? and defined?(target.user.id)
-					payload['text'] = payload['text'].prepend("<@#{target.user.id}> ")
-				end
-				return payload
-			end
+      def listen_to_sqs
+        return unless config.sqs_queue_name
+        require 'lita/adapters/slack/sqs_subscriber'
+        SqsSubscriber.listen(robot)
+        log.debug 'Listening to SQS messages'
+      end
 
-			def http_post(payload)
-				res = Faraday.post do |req|
-					log.debug "Slack::http_post sending payload to #{incoming_url}; length: #{payload.to_json.size}"
-					req.url config.incoming_url, :token => config.incoming_token
-					req.headers['Content-Type'] = 'application/json'
-					req.body = payload.to_json
-				end
-				log.info "Slack::http_post sent payload with response status #{res.status}"
-				log.debug "Slack::http_post response body: #{res.body}"
-				return res.status
-			end
+      def prepare_payload(target, strings)
+        if not defined?(target.room)
+          channel_id = nil
+          log.warn "Slack::prepare_payload proceeding without channel designation"
+        else
+          channel_id = target.room
+        end
+        payload = {'channel' => channel_id, 'username' => username}
+        payload['text'] = strings.join('\n')
+        if add_mention? and defined?(target.user.id)
+          payload['text'] = payload['text'].prepend("<@#{target.user.id}> ")
+        end
+        payload
+      end
 
-			#
-			# Accessor shortcuts
-			#
-			def config
-				Lita.config.adapter
-			end
+      def http_post(payload)
+        res = Faraday.post do |req|
+          log.debug "Slack::http_post sending payload to #{incoming_url}; length: #{payload.to_json.size}"
+          req.url incoming_url, :token => config.incoming_token
+          req.headers['Content-Type'] = 'application/json'
+          req.body = payload.to_json
+        end
+        log.info "Slack::http_post sent payload with response status #{res.status}"
+        log.debug "Slack::http_post response body: #{res.body}"
+        res.status
+      end
 
-			def log
-				Lita.logger
-			end
+      #
+      # Accessor shortcuts
+      #
+      def config
+        Lita.config.adapter
+      end
+
+      def log
+        Lita.logger
+      end
 
       def incoming_url
         config.incoming_url ||
@@ -83,9 +91,9 @@ module Lita
       def add_mention?
         config.add_mention
       end
-		end
+    end
 
-		# Register Slack adapter to Lita
-		Lita.register_adapter(:slack, Slack)
-	end
+    # Register Slack adapter to Lita
+    Lita.register_adapter(:slack, Slack)
+  end
 end

--- a/lib/lita/adapters/slack/sqs_sender.rb
+++ b/lib/lita/adapters/slack/sqs_sender.rb
@@ -1,0 +1,69 @@
+module Lita
+  module Adapters
+    class SqsSender
+      def self.deliver(robot, message, config)
+        new(robot, config).deliver(message)
+      end
+
+      def initialize(robot, config)
+        @robot = robot
+        @config = config
+      end
+
+      def deliver(message)
+        parse(message)
+        @robot.receive(lita_message) if channel_whitelisted? && not_self?
+      end
+
+      private
+
+      def parse(message)
+        @payload = JSON.parse(message.body)
+      end
+
+      def not_self?
+        robot_id != user_id
+      end
+
+      def channel_whitelisted?
+        channel_ids.nil? || channel_ids.include?(channel_id)
+      end
+
+      def robot_id
+        @config.robot_id
+      end
+
+      def channel_ids
+        @config.channel_ids
+      end
+
+      def user_id
+        @payload['user_id']
+      end
+
+      def user_name
+        @payload['user_name']
+      end
+
+      def channel_id
+        @payload['channel_id']
+      end
+
+      def text
+        @payload['text']
+      end
+
+      def user
+        Lita::User.create(user_id, user_name: user_name)
+      end
+
+      def source
+        Lita::Source.new(user: user, room: channel_id)
+      end
+
+      def lita_message
+        Lita::Message.new(@robot, text, source)
+      end
+    end
+  end
+end

--- a/lib/lita/adapters/slack/sqs_subscriber.rb
+++ b/lib/lita/adapters/slack/sqs_subscriber.rb
@@ -1,0 +1,44 @@
+require 'aws-sdk'
+require 'lita/adapters/slack/sqs_sender'
+
+module Lita
+  module Adapters
+    class Slack < Adapter
+      class SqsSubscriber
+        def self.listen(robot)
+          new.listen(robot)
+        end
+
+        def listen(robot)
+          Thread.new do
+            queue.poll do |message|
+              SqsSender.deliver(robot, message, config)
+              message.delete
+            end
+          end
+        end
+
+        private
+
+        def robot_id
+          config.robot_id
+        end
+
+        def queue
+          sqs.queues.named(config.sqs_queue_name)
+        end
+
+        def sqs
+          AWS::SQS.new(
+            access_key_id: config.sqs_aws_access_key_id,
+            secret_access_key: config.sqs_aws_secret_access_key
+          )
+        end
+
+        def config
+          Lita.config.adapter
+        end
+      end
+    end
+  end
+end

--- a/spec/lita/adapters/slack/sqs_sender_spec.rb
+++ b/spec/lita/adapters/slack/sqs_sender_spec.rb
@@ -1,0 +1,81 @@
+require 'spec_helper'
+require 'lita/adapters/slack/sqs_sender'
+
+describe Lita::Adapters::SqsSender do
+  let(:robot) do
+    double(
+      Lita::Robot,
+      mention_name: 'robot',
+      alias: 'robot'
+    )
+  end
+  let(:robot_adapter) { double(:adapter, config_attributes) }
+  let(:user_id) { 'U2147483697' }
+  let(:user_name) { 'Steve' }
+  let(:text) { 'long text' }
+  let(:channel_id) { 'AHH3246JD' }
+  let(:user) { instance_double(Lita::User) }
+  let(:source) { instance_double(Lita::Source) }
+  let(:sqs_message) { instance_double(AWS::SQS::ReceivedMessage, body: message_body) }
+  let(:message) { instance_double(Lita::Message) }
+
+  describe '.deliver' do
+    before do
+      allow(Lita::User).to receive(:create).
+        with(user_id, user_name: user_name).
+        and_return(user)
+      allow(Lita::Source).to receive(:new).
+        with(user: user, room: channel_id).
+        and_return(source)
+      allow(Lita::Message).to receive(:new).
+        with(robot, text, source).
+        and_return(message)
+
+    end
+
+    context 'when origin channel is whitelisted' do
+      context 'when a message does not come from itself' do
+        let(:config_attributes) { { robot_id: 'UANOTHERONE', channel_ids: [channel_id] } }
+
+        it 'delivers a new message to the robot' do
+          expect(robot).to receive(:receive).with(message)
+          described_class.deliver(robot, sqs_message, robot_adapter)
+        end
+      end
+
+      context 'when a message come from itself' do
+        let(:config_attributes) { { robot_id: user_id, channel_ids: [channel_id] } }
+
+        it 'does not deliver a new message to the robot' do
+          expect(robot).not_to receive(:receive).with(message)
+          described_class.deliver(robot, sqs_message, robot_adapter)
+        end
+      end
+    end
+  end
+
+  context 'when origin channel is not whitelisted' do
+    let(:config_attributes) { { robot_id: 'UANOTHERONE', channel_ids: ['NOCHANNEL'] } }
+
+    it 'does not receive a message' do
+      expect(robot).not_to receive(:receive)
+      described_class.deliver(robot, sqs_message, robot_adapter)
+    end
+  end
+
+  context 'when channel_ids is not defined' do
+    let(:config_attributes) { { robot_id: 'UANOTHERONE', channel_ids: nil } }
+
+    it 'receives a message' do
+      expect(robot).to receive(:receive)
+      described_class.deliver(robot, sqs_message, robot_adapter)
+    end
+  end
+
+  def message_body
+    '{"token": "q3it7HawhPvos4eb7a0Fn508", "team_id": "T0001",' +
+      %Q["channel_id": "#{channel_id}", "channel_name": "test",] +
+      %Q["timestamp": "1355517523.000005", "user_id": "#{user_id}",] +
+      %Q["user_name": "#{user_name}", "text": "#{text}" }]
+  end
+end

--- a/spec/lita/adapters/slack/sqs_subscriber_spec.rb
+++ b/spec/lita/adapters/slack/sqs_subscriber_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+require 'lita/adapters/slack/sqs_subscriber'
+
+describe Lita::Adapters::Slack::SqsSubscriber do
+  let(:queue) { instance_double(AWS::SQS::Queue) }
+  let(:queues) { instance_double(AWS::SQS::QueueCollection) }
+  let(:sqs_client) { instance_double(AWS::SQS, queues: queues) }
+  let(:sqs_message) { instance_double(AWS::SQS::ReceivedMessage) }
+  let(:robot) { instance_double(Lita::Robot) }
+  let(:config) { Lita.config.adapter }
+  before do
+    Lita.configure do |config|
+      config.adapter.sqs_aws_access_key_id = 'keyid'
+      config.adapter.sqs_aws_secret_access_key = 'secretkey'
+      config.adapter.sqs_queue_name = 'queuename'
+    end
+  end
+
+  describe '.listen' do
+    before do
+      allow(AWS::SQS).to receive(:new).
+        with(access_key_id: 'keyid', secret_access_key: 'secretkey').
+        and_return(sqs_client)
+      allow(queues).to receive(:named).with('queuename').and_return(queue)
+      allow(queue).to receive(:poll).and_yield(sqs_message)
+      allow(Thread).to receive(:new).and_yield
+    end
+
+    it 'fetches SQS events and processes them' do
+      expect(Lita::Adapters::SqsSender).to receive(:deliver).
+        with(robot, sqs_message, config)
+      expect(sqs_message).to receive(:delete)
+      described_class.listen(robot)
+    end
+  end
+end

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -1,53 +1,53 @@
 require "spec_helper"
 
 describe Lita::Adapters::Slack, lita: true do
-	before do
-		Lita.configure do |config|
-			config.adapter.incoming_token = 'aN1NvAlIdDuMmYt0k3n'
-			config.adapter.team_domain = 'example'
-			config.adapter.username = 'lita'
-			config.adapter.add_mention = true
-		end
-	end
+  before do
+    Lita.configure do |config|
+      config.adapter.incoming_token = 'aN1NvAlIdDuMmYt0k3n'
+      config.adapter.team_domain = 'example'
+      config.adapter.username = 'lita'
+      config.adapter.add_mention = true
+    end
+  end
 
-	subject { described_class.new(robot) }
-	let(:robot) { double("Lita::Robot") }
+  subject { described_class.new(robot) }
+  let(:robot) { double("Lita::Robot") }
 
-	it "registers with Lita" do
-		expect(Lita.adapters[:slack]).to eql(described_class)
-	end
+  it "registers with Lita" do
+    expect(Lita.adapters[:slack]).to eql(described_class)
+  end
 
-	it "fails without valid config: incoming_token and team_domain" do
-		Lita.clear_config
-		expect(Lita.logger).to receive(:fatal).with(/incoming_token, team_domain/)
-		expect { subject }.to raise_error(SystemExit)
-	end
+  it "fails without valid config: incoming_token and team_domain" do
+    Lita.clear_config
+    expect(Lita.logger).to receive(:fatal).with(/incoming_token, team_domain/)
+    expect { subject }.to raise_error(SystemExit)
+  end
 
-	describe "#send_messages" do
-		it "sends JSON payload via HTTP POST to Slack channel" do
-			target = double("Lita::Source", room: "CR00M1D")
-			payload = {'channel' => target.room, 'username' => Lita.config.adapter.username, 'text' => 'Hello!'}
-			expect(subject).to receive(:http_post).with(payload)
-			subject.send_messages(target, ["Hello!"])
-		end
+  describe "#send_messages" do
+    it "sends JSON payload via HTTP POST to Slack channel" do
+      target = double("Lita::Source", room: "CR00M1D")
+      payload = {'channel' => target.room, 'username' => Lita.config.adapter.username, 'text' => 'Hello!'}
+      expect(subject).to receive(:http_post).with(payload)
+      subject.send_messages(target, ["Hello!"])
+    end
 
-		it "sends message with mention if user info is provided" do
-			user = double("Lita::User", id: "UM3NT10N")
-			target = double("Lita::Source", room: "CR00M1D", user: user)
-			text = "<@#{user.id}> Hello!"
-			payload = {'channel' => target.room, 'username' => Lita.config.adapter.username, 'text' => text}
-			expect(subject).to receive(:http_post).with(payload)
-			subject.send_messages(target, ["Hello!"])
-		end
+    it "sends message with mention if user info is provided" do
+      user = double("Lita::User", id: "UM3NT10N")
+      target = double("Lita::Source", room: "CR00M1D", user: user)
+      text = "<@#{user.id}> Hello!"
+      payload = {'channel' => target.room, 'username' => Lita.config.adapter.username, 'text' => text}
+      expect(subject).to receive(:http_post).with(payload)
+      subject.send_messages(target, ["Hello!"])
+    end
 
-		it "proceeds but logs WARN when directed to an user without channel(room) info" do
-			user = double("Lita::User", id: "UM3NT10N")
-			target = double("Lita::Source", user: user)
-			text = "<@#{user.id}> Hello!"
-			payload = {'channel' => nil, 'username' => Lita.config.adapter.username, 'text' => text}
-			expect(subject).to receive(:http_post).with(payload)
-			expect(Lita.logger).to receive(:warn).with(/without channel/)
-			subject.send_messages(target, ["Hello!"])
-		end
-	end
+    it "proceeds but logs WARN when directed to an user without channel(room) info" do
+      user = double("Lita::User", id: "UM3NT10N")
+      target = double("Lita::Source", user: user)
+      text = "<@#{user.id}> Hello!"
+      payload = {'channel' => nil, 'username' => Lita.config.adapter.username, 'text' => text}
+      expect(subject).to receive(:http_post).with(payload)
+      expect(Lita.logger).to receive(:warn).with(/without channel/)
+      subject.send_messages(target, ["Hello!"])
+    end
+  end
 end


### PR DESCRIPTION
As `lita-slack-adapter` needs to expose robot to internet to let out outgoing webhook hit robot, and as Lita does not suppor multiple adapters yet, I've written a SQS module to subscribe from a SQS queue to feed robot with messages in the queue.

`aws-sdk` is loaded when `sqs_queue_name` is declared, and also there are new optional config variables to work with SQS.
