### PR TITLE
Sending message fails if config.incoming_url is not set

### DIFF
--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -51,7 +51,7 @@ module Lita
 			def http_post(payload)
 				res = Faraday.post do |req|
 					log.debug "Slack::http_post sending payload to #{incoming_url}; length: #{payload.to_json.size}"
-					req.url config.incoming_url, :token => config.incoming_token
+					req.url incoming_url, :token => config.incoming_token
 					req.headers['Content-Type'] = 'application/json'
 					req.body = payload.to_json
 				end


### PR DESCRIPTION
The fix is to always use the `incoming_url` method which has a default if the config is not set.
