### PR TITLE
Update create bot link to point at the Lita page on Slack.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ gem "lita-slack"
 
 ### Required attributes
 
-* `token` (String) – The bot's Slack API token. Create a bot and get its token at https://my.slack.com/services/new/bot.
+* `token` (String) – The bot's Slack API token. Create a bot and get its token at https://my.slack.com/services/new/lita.
 
 **Note**: When using lita-slack, the adapter will overwrite the bot's name and mention name with the values set on the server, so `config.robot.name` and `config.robot.mention_name` will have no effect.
 


### PR DESCRIPTION
This pull request updates the link to create a bot in the README to point at a new Lita integration page on slack.com that @jimmycuadra and I have been working on.

Also: thanks for all your work on building this adapter, we're really excited to get this out to everyone!
