### PR TITLE
Add reaction

### DIFF
--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -30,6 +30,16 @@ module Lita
           )
         end
 
+        def add_reaction(message, name)
+          call_api(
+              "reactions.add",
+              as_user: true,
+              channel: message.room_object.id,
+              timestamp: message.adapter_data['ts'],
+              name: name,
+          )
+        end
+
         def set_topic(channel, topic)
           call_api("channels.setTopic", channel: channel, topic: topic)
         end

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -35,7 +35,7 @@ module Lita
               "reactions.add",
               as_user: true,
               channel: message.room_object.id,
-              timestamp: message.adapter_data['ts'],
+              timestamp: message.extensions[:slack]['ts'],
               name: name,
           )
         end

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -40,6 +40,16 @@ module Lita
           )
         end
 
+        def remove_reaction(message, name)
+          call_api(
+              "reactions.remove",
+              as_user: true,
+              channel: message.room_object.id,
+              timestamp: message.extensions[:slack]['ts'],
+              name: name,
+          )
+        end
+
         def set_topic(channel, topic)
           call_api("channels.setTopic", channel: channel, topic: topic)
         end

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -32,11 +32,11 @@ module Lita
 
         def add_reaction(message, name)
           call_api(
-              "reactions.add",
-              as_user: true,
-              channel: message.room_object.id,
-              timestamp: message.extensions[:slack]['ts'],
-              name: name,
+            "reactions.add",
+            as_user: true,
+            channel: message.room_object.id,
+            timestamp: message.extensions[:slack]['ts'],
+            name: name,
           )
         end
 

--- a/lib/lita/adapters/slack/chat_service.rb
+++ b/lib/lita/adapters/slack/chat_service.rb
@@ -23,6 +23,14 @@ module Lita
           api.send_attachments(target, Array(attachments))
         end
         alias_method :send_attachment, :send_attachments
+
+        # @param message [Lita::Message] A message to add a reaction to
+        # @param name [String] Name of the emoji reaction to add
+        # @since 1.7.3
+        # @return [void]
+        def add_reaction(message, name)
+          api.add_reaction(message, name)
+        end
       end
     end
   end

--- a/lib/lita/adapters/slack/chat_service.rb
+++ b/lib/lita/adapters/slack/chat_service.rb
@@ -26,7 +26,7 @@ module Lita
 
         # @param message [Lita::Message] A message to add a reaction to
         # @param name [String] Name of the emoji reaction to add
-        # @since 1.7.3
+        # @since 1.8.2
         # @return [void]
         def add_reaction(message, name)
           api.add_reaction(message, name)

--- a/lib/lita/adapters/slack/chat_service.rb
+++ b/lib/lita/adapters/slack/chat_service.rb
@@ -31,6 +31,14 @@ module Lita
         def add_reaction(message, name)
           api.add_reaction(message, name)
         end
+
+        # @param message [Lita::Message] A message to remove a reaction from
+        # @param name [String] Name of the emoji reaction to remove
+        # @since 1.8.2
+        # @return [void]
+        def remove_reaction(message, name)
+          api.remove_reaction(message, name)
+        end
       end
     end
   end

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -113,7 +113,7 @@ module Lita
         def dispatch_message(user)
           source = Source.new(user: user, room: channel)
           source.private_message! if channel && channel[0] == "D"
-          message = Message.new(robot, body, source)
+          message = Message.new(robot, body, source, @data)
           message.command! if source.private_message?
           log.debug("Dispatching message to Lita from #{user.id}.")
           robot.receive(message)

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -113,7 +113,8 @@ module Lita
         def dispatch_message(user)
           source = Source.new(user: user, room: channel)
           source.private_message! if channel && channel[0] == "D"
-          message = Message.new(robot, body, source, @data)
+          message = Message.new(robot, body, source)
+          message.extensions[:slack] = @data
           message.command! if source.private_message?
           log.debug("Dispatching message to Lita from #{user.id}.")
           robot.receive(message)

--- a/lita-slack.gemspec
+++ b/lita-slack.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "eventmachine"
   spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "faye-websocket", ">= 0.8.0"
-  spec.add_runtime_dependency "lita", ">= 4.6.0"
+  spec.add_runtime_dependency "lita", ">= 4.7.0"
   spec.add_runtime_dependency "multi_json"
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/lita-slack.gemspec
+++ b/lita-slack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-slack"
-  spec.version       = "1.7.3"
+  spec.version       = "1.8.2"
   spec.authors       = ["Ken J.", "Jimmy Cuadra"]
   spec.email         = ["kenjij@gmail.com", "jimmy@jimmycuadra.com"]
   spec.description   = %q{Lita adapter for Slack.}

--- a/lita-slack.gemspec
+++ b/lita-slack.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "lita-slack"
-  spec.version       = "1.7.2"
+  spec.version       = "1.7.3"
   spec.authors       = ["Ken J.", "Jimmy Cuadra"]
   spec.email         = ["kenjij@gmail.com", "jimmy@jimmycuadra.com"]
   spec.description   = %q{Lita adapter for Slack.}

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -66,6 +66,67 @@ describe Lita::Adapters::Slack::API do
     end
   end
 
+  describe "#add_reaction" do
+    let(:http_response) { MultiJson.dump({ ok: true }) }
+    let(:room) { Lita::Room.new("C1234567890") }
+    let(:registry) { Lita::Registry.new }
+    let(:robot) { Lita::Robot.new(registry) }
+    let(:message) do
+      Lita::Message.new(robot, "Hello!", Lita::Source.new(room: room)).tap do |msg|
+        msg.extensions[:slack] = {'ts' => '123456.7890'}
+      end
+    end
+
+    let(:name) { 'thumbsup' }
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.post(
+            "https://slack.com/api/reactions.add",
+            as_user: true,
+            channel: message.room_object.id,
+            timestamp: message.extensions[:slack]['ts'],
+            name: name,
+            token: token
+        ) do
+          [http_status, {}, http_response]
+        end
+      end
+    end
+
+    it "adds the reaction" do
+      response = subject.add_reaction(message, name)
+
+      expect(response['ok']).to be(true)
+    end
+
+    context "with a Slack error" do
+      let(:http_response) do
+        MultiJson.dump({
+          ok: false,
+          error: 'invalid_auth'
+        })
+      end
+
+      it "raises a RuntimeError" do
+        expect { subject.add_reaction(message, name) }.to raise_error(
+          "Slack API call to reactions.add returned an error: invalid_auth."
+        )
+      end
+    end
+
+    context "with an HTTP error" do
+      let(:http_status) { 422 }
+      let(:http_response) { '' }
+
+      it "raises a RuntimeError" do
+        expect { subject.add_reaction(message, name) }.to raise_error(
+          "Slack API call to reactions.add failed with status code 422."
+        )
+      end
+    end
+
+  end
+
   describe "#send_attachments" do
     let(:attachment) do
       Lita::Adapters::Slack::Attachment.new(attachment_text)

--- a/spec/lita/adapters/slack/chat_service_spec.rb
+++ b/spec/lita/adapters/slack/chat_service_spec.rb
@@ -38,4 +38,15 @@ describe Lita::Adapters::Slack::ChatService, lita: true do
       subject.add_reaction(message, name)
     end
   end
+
+  describe "#remove_reaction" do
+    let(:message) { Lita::Message.new(robot, "Hello", Lita::Source.new(room: room)) }
+    let(:name) { "thumbsup" }
+
+    it "can remove a reaction" do
+      expect(subject.api).to receive(:remove_reaction).with(message, name)
+
+      subject.remove_reaction(message, name)
+    end
+  end
 end

--- a/spec/lita/adapters/slack/chat_service_spec.rb
+++ b/spec/lita/adapters/slack/chat_service_spec.rb
@@ -4,6 +4,7 @@ describe Lita::Adapters::Slack::ChatService, lita: true do
   subject { described_class.new(adapter.config) }
 
   let(:adapter) { Lita::Adapters::Slack.new(robot) }
+  let(:registry) { Lita::Registry.new }
   let(:robot) { Lita::Robot.new(registry) }
   let(:room) { Lita::Room.new("C2147483705") }
 
@@ -24,6 +25,17 @@ describe Lita::Adapters::Slack::ChatService, lita: true do
       expect(subject.api).to receive(:send_attachments).with(room, [attachment])
 
       subject.send_attachment(room, attachment)
+    end
+  end
+
+  describe "#add_reaction" do
+    let(:message) { Lita::Message.new(robot, "Hello", Lita::Source.new(room: room)) }
+    let(:name) { "thumbsup" }
+
+    it "can respond with a reaction" do
+      expect(subject.api).to receive(:add_reaction).with(message, name)
+
+      subject.add_reaction(message, name)
     end
   end
 end

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -44,6 +44,7 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           room: "C2147483705"
         ).and_return(source)
         allow(Lita::Message).to receive(:new).with(robot, "Hello", source).and_return(message)
+        allow(message).to receive(:extensions).and_return({})
         allow(robot).to receive(:receive).with(message)
       end
 


### PR DESCRIPTION
Implements API to add an emoji reaction to an incoming message. Also implements the passing of Slack-provided message data via a proposed change to `Lita` (https://github.com/litaio/lita/pull/164), as required to add a reaction.

- [x] Add functionality
- [x] Add tests (waiting on PR merge)
- [x] Bump gem version dependency for `Lita` (waiting on PR merge)