### PR TITLE
Store timestamp of message in Message.extensions

### DIFF
--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -115,7 +115,7 @@ module Lita
           source.private_message! if channel && channel[0] == "D"
           message = Message.new(robot, body, source)
           message.command! if source.private_message?
-          message.extensions = { 'slack': { 'timestamp': data['ts'] } }
+          message.extensions[:slack] = { timestamp: data["ts"] }
           log.debug("Dispatching message to Lita from #{user.id}.")
           robot.receive(message)
         end

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -115,6 +115,7 @@ module Lita
           source.private_message! if channel && channel[0] == "D"
           message = Message.new(robot, body, source)
           message.command! if source.private_message?
+          message.extensions['timestamp'] = data['ts']
           log.debug("Dispatching message to Lita from #{user.id}.")
           robot.receive(message)
         end

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -115,7 +115,7 @@ module Lita
           source.private_message! if channel && channel[0] == "D"
           message = Message.new(robot, body, source)
           message.command! if source.private_message?
-          message.extensions['timestamp'] = data['ts']
+          message.extensions = { 'slack': { 'timestamp': data['ts'] } }
           log.debug("Dispatching message to Lita from #{user.id}.")
           robot.receive(message)
         end

--- a/lita-slack.gemspec
+++ b/lita-slack.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "eventmachine"
   spec.add_runtime_dependency "faraday"
   spec.add_runtime_dependency "faye-websocket", ">= 0.8.0"
-  spec.add_runtime_dependency "lita", ">= 4.6.0"
+  spec.add_runtime_dependency "lita", ">= 4.7.0"
   spec.add_runtime_dependency "multi_json"
 
   spec.add_development_dependency "bundler", "~> 1.3"

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -55,7 +55,7 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
 
       it "saves the timestamp in extensions" do
         subject.handle
-        expect(message.extensions["timestamp"]).to eq("1234.5678")
+        expect(message.extensions["slack"]["timestamp"]).to eq("1234.5678")
       end
 
       context "when the message is a direct message" do

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -30,10 +30,11 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           "type" => "message",
           "channel" => "C2147483705",
           "user" => "U023BECGF",
-          "text" => "Hello"
+          "text" => "Hello",
+          "ts" => "1234.5678"
         }
       end
-      let(:message) { instance_double('Lita::Message', command!: false) }
+      let(:message) { instance_double('Lita::Message', command!: false, extensions: {}) }
       let(:source) { instance_double('Lita::Source', private_message?: false) }
       let(:user) { instance_double('Lita::User', id: 'U023BECGF') }
 
@@ -49,8 +50,12 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
 
       it "dispatches the message to Lita" do
         expect(robot).to receive(:receive).with(message)
-
         subject.handle
+      end
+
+      it "saves the timestamp in extensions" do
+        subject.handle
+        expect(message.extensions["timestamp"]).to eq("1234.5678")
       end
 
       context "when the message is a direct message" do

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -55,7 +55,7 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
 
       it "saves the timestamp in extensions" do
         subject.handle
-        expect(message.extensions["slack"]["timestamp"]).to eq("1234.5678")
+        expect(message.extensions[:slack][:timestamp]).to eq("1234.5678")
       end
 
       context "when the message is a direct message" do


### PR DESCRIPTION
Timestamps of an incoming message, being its only _unique identifier_ needs to be stored for referring back to the message (for eg: to associate reactions to it). This PR proposes using the newly introduced `extensions` hash of the `Message` object to store the same while dispatching. 