### PR TITLE
Use the Web API to submit messages in full parse mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ gem "lita-slack"
 ### Optional attributes
 
 * `proxy` (String) – Specify a HTTP proxy URL. (e.g. "http://squid.example.com:3128")
-* `send_via_rtm_api` (Symbol) – Defaults to :yes. Whether or not to use the RTM API for sending messages. RTM API does not support advanced formatting (https://api.slack.com/docs/formatting)
 
 **Note**: When using lita-slack, the adapter will overwrite the bot's name and mention name with the values set on the server, so `config.robot.name` and `config.robot.mention_name` will have no effect.
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ gem "lita-slack"
 ### Optional attributes
 
 * `proxy` (String) – Specify a HTTP proxy URL. (e.g. "http://squid.example.com:3128")
+* `send_via_rtm_api` (Symbol) – Defaults to :yes. Whether or not to use the RTM API for sending messages. RTM API does not support advanced formatting (https://api.slack.com/docs/formatting)
 
 **Note**: When using lita-slack, the adapter will overwrite the bot's name and mention name with the values set on the server, so `config.robot.name` and `config.robot.mention_name` will have no effect.
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Lita.configure do |config|
   config.robot.adapter = :slack
   config.robot.admins = ["U012A3BCD"]
   config.adapters.slack.token = "abcd-1234567890-hWYd21AmMH2UHAkx29vb5c1Y"
+  config.adapters.slack.parse = "full" # See https://api.slack.com/docs/formatting#parsing_modes
 end
 ```
 

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -9,7 +9,6 @@ module Lita
       # Required configuration attributes.
       config :token, type: String, required: true
       config :proxy, type: String
-      config :send_via_rtm_api, type: Symbol, default: :yes
 
       # Provides an object for Slack-specific features.
       def chat_service
@@ -29,13 +28,8 @@ module Lita
       end
 
       def send_messages(target, strings)
-        if send_via_rtm_api?
-          return unless rtm_connection
-          rtm_connection.send_messages(channel_for(target), strings)
-        else
-          api = API.new(config)
-          api.send_messages(channel_for(target), strings)
-        end
+        api = API.new(config)
+        api.send_messages(channel_for(target), strings)
       end
 
       def set_topic(target, topic)
@@ -61,10 +55,6 @@ module Lita
         else
           target.room
         end
-      end
-
-      def send_via_rtm_api?
-        config.send_via_rtm_api != :no
       end
     end
 

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -9,6 +9,7 @@ module Lita
       # Required configuration attributes.
       config :token, type: String, required: true
       config :proxy, type: String
+      config :parse, type: String
 
       # Provides an object for Slack-specific features.
       def chat_service

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -9,6 +9,7 @@ module Lita
       # Required configuration attributes.
       config :token, type: String, required: true
       config :proxy, type: String
+      config :send_via_rtm_api, type: Symbol, default: :yes
 
       # Provides an object for Slack-specific features.
       def chat_service
@@ -28,9 +29,13 @@ module Lita
       end
 
       def send_messages(target, strings)
-        return unless rtm_connection
-
-        rtm_connection.send_messages(channel_for(target), strings)
+        if send_via_rtm_api?
+          return unless rtm_connection
+          rtm_connection.send_messages(channel_for(target), strings)
+        else
+          api = API.new(config)
+          api.send_messages(channel_for(target), strings)
+        end
       end
 
       def set_topic(target, topic)
@@ -56,6 +61,10 @@ module Lita
         else
           target.room
         end
+      end
+
+      def send_via_rtm_api?
+        config.send_via_rtm_api != :no
       end
     end
 

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -36,7 +36,7 @@ module Lita
             as_user: true,
             channel: channel_id,
             text: messages.join("\n"),
-            parse: 'full',
+            parse: config.parse,
           )
         end
 

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -30,6 +30,15 @@ module Lita
           )
         end
 
+        def send_messages(channel_id, messages)
+          call_api(
+            "chat.postMessage",
+            as_user: true,
+            channel: channel_id,
+            text: messages.join("\n")
+          )
+        end
+
         def set_topic(channel, topic)
           call_api("channels.setTopic", channel: channel, topic: topic)
         end

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -35,7 +35,8 @@ module Lita
             "chat.postMessage",
             as_user: true,
             channel: channel_id,
-            text: messages.join("\n")
+            text: messages.join("\n"),
+            parse: 'full',
           )
         end
 

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -179,6 +179,109 @@ describe Lita::Adapters::Slack::API do
     end
   end
 
+  describe "#send_messages" do
+    let(:messages) { ["attachment text"] }
+    let(:http_response) { MultiJson.dump({ ok: true }) }
+    let(:room) { "C1234567890" }
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.post(
+          "https://slack.com/api/chat.postMessage",
+          token: token,
+          as_user: true,
+          channel: room,
+          text: messages.join("\n"),
+        ) do
+          [http_status, {}, http_response]
+        end
+      end
+    end
+
+    context "with a simple text attachment" do
+      it "sends the attachment" do
+        response = subject.send_messages(room, messages)
+
+        expect(response['ok']).to be(true)
+      end
+    end
+
+    context "with a different fallback message" do
+      let(:attachment) do
+        Lita::Adapters::Slack::Attachment.new(attachment_text, fallback: fallback_text)
+      end
+      let(:fallback_text) { "fallback text" }
+
+      it "sends the attachment" do
+        response = subject.send_messages(room, messages)
+
+        expect(response['ok']).to be(true)
+      end
+    end
+
+    context "with all the valid options" do
+      let(:attachment) do
+        Lita::Adapters::Slack::Attachment.new(attachment_text, common_hash_data)
+      end
+      let(:attachment_hash) do
+        common_hash_data.merge(fallback: attachment_text, text: attachment_text)
+      end
+      let(:common_hash_data) do
+        {
+          author_icon: "http://example.com/author.jpg",
+          author_link: "http://example.com/author",
+          author_name: "author name",
+          color: "#36a64f",
+          fields: [{
+            title: "priority",
+            value: "high",
+            short: true,
+          }, {
+            title: "super long field title",
+            value: "super long field value",
+            short: false,
+          }],
+          image_url: "http://example.com/image.jpg",
+          pretext: "pretext",
+          thumb_url: "http://example.com/thumb.jpg",
+          title: "title",
+          title_link: "http://example.com/title",
+        }
+      end
+
+      it "sends the attachment" do
+        response = subject.send_messages(room, messages)
+
+        expect(response['ok']).to be(true)
+      end
+    end
+
+    context "with a Slack error" do
+      let(:http_response) do
+        MultiJson.dump({
+          ok: false,
+          error: 'invalid_auth'
+        })
+      end
+
+      it "raises a RuntimeError" do
+        expect { subject.send_messages(room, messages) }.to raise_error(
+          "Slack API call to chat.postMessage returned an error: invalid_auth."
+        )
+      end
+    end
+
+    context "with an HTTP error" do
+      let(:http_status) { 422 }
+      let(:http_response) { '' }
+
+      it "raises a RuntimeError" do
+        expect { subject.send_messages(room, messages) }.to raise_error(
+          "Slack API call to chat.postMessage failed with status code 422."
+        )
+      end
+    end
+  end
+
   describe "#set_topic" do
     let(:channel) { 'C1234567890' }
     let(:topic) { 'Topic' }

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -191,6 +191,7 @@ describe Lita::Adapters::Slack::API do
           as_user: true,
           channel: room,
           text: messages.join("\n"),
+          parse: nil,
         ) do
           [http_status, {}, http_response]
         end

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -56,47 +56,11 @@ describe Lita::Adapters::Slack, lita: true do
       Lita::Source.new(room: 'C024BE91L', user: user, private_message: true)
     end
 
-    describe "via the RTM API" do
-      before do
-        registry.config.adapters.slack.send_via_rtm_api = :yes
-      end
-
-      it "sends messages to rooms" do
-        expect(rtm_connection).to receive(:send_messages).with(room_source.room, ['foo'])
-
-        subject.run
-
-        subject.send_messages(room_source, ['foo'])
-      end
-
-      it "sends messages to users" do
-        allow(rtm_connection).to receive(:im_for).with(user.id).and_return('D024BFF1M')
-
-        expect(rtm_connection).to receive(:send_messages).with('D024BFF1M', ['foo'])
-
-        subject.run
-
-        subject.send_messages(user_source, ['foo'])
-      end
-
-      it "sends messages to users when the source is marked as a private message" do
-        allow(rtm_connection).to receive(:im_for).with(user.id).and_return('D024BFF1M')
-
-        expect(rtm_connection).to receive(:send_messages).with('D024BFF1M', ['foo'])
-
-        subject.run
-
-        subject.send_messages(private_message_source, ['foo'])
-      end
-    end
-
     describe "via the Web API" do
       let(:api) { instance_double('Lita::Adapters::Slack::API') }
 
       before do
         allow(Lita::Adapters::Slack::API).to receive(:new).with(subject.config).and_return(api)
-
-        registry.config.adapters.slack.send_via_rtm_api = :no
       end
 
       it "does not send via the RTM api" do

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -1,5 +1,5 @@
-require "spec_helper"
 
+require "spec_helper"
 describe Lita::Adapters::Slack, lita: true do
   subject { described_class.new(robot) }
 
@@ -56,32 +56,55 @@ describe Lita::Adapters::Slack, lita: true do
       Lita::Source.new(room: 'C024BE91L', user: user, private_message: true)
     end
 
-    it "sends messages to rooms" do
-      expect(rtm_connection).to receive(:send_messages).with(room_source.room, ['foo'])
+    describe "via the RTM API" do
+      before do
+        registry.config.adapters.slack.send_via_rtm_api = :yes
+      end
 
-      subject.run
+      it "sends messages to rooms" do
+        expect(rtm_connection).to receive(:send_messages).with(room_source.room, ['foo'])
 
-      subject.send_messages(room_source, ['foo'])
+        subject.run
+
+        subject.send_messages(room_source, ['foo'])
+      end
+
+      it "sends messages to users" do
+        allow(rtm_connection).to receive(:im_for).with(user.id).and_return('D024BFF1M')
+
+        expect(rtm_connection).to receive(:send_messages).with('D024BFF1M', ['foo'])
+
+        subject.run
+
+        subject.send_messages(user_source, ['foo'])
+      end
+
+      it "sends messages to users when the source is marked as a private message" do
+        allow(rtm_connection).to receive(:im_for).with(user.id).and_return('D024BFF1M')
+
+        expect(rtm_connection).to receive(:send_messages).with('D024BFF1M', ['foo'])
+
+        subject.run
+
+        subject.send_messages(private_message_source, ['foo'])
+      end
     end
 
-    it "sends messages to users" do
-      allow(rtm_connection).to receive(:im_for).with(user.id).and_return('D024BFF1M')
+    describe "via the Web API" do
+      let(:api) { instance_double('Lita::Adapters::Slack::API') }
 
-      expect(rtm_connection).to receive(:send_messages).with('D024BFF1M', ['foo'])
+      before do
+        allow(Lita::Adapters::Slack::API).to receive(:new).with(subject.config).and_return(api)
 
-      subject.run
+        registry.config.adapters.slack.send_via_rtm_api = :no
+      end
 
-      subject.send_messages(user_source, ['foo'])
-    end
+      it "does not send via the RTM api" do
+        expect(rtm_connection).to_not receive(:send_messages)
+        expect(api).to receive(:send_messages).with(room_source.room, ['foo'])
 
-    it "sends messages to users when the source is marked as a private message" do
-      allow(rtm_connection).to receive(:im_for).with(user.id).and_return('D024BFF1M')
-
-      expect(rtm_connection).to receive(:send_messages).with('D024BFF1M', ['foo'])
-
-      subject.run
-
-      subject.send_messages(private_message_source, ['foo'])
+        subject.send_messages(room_source, ['foo'])
+      end
     end
   end
 


### PR DESCRIPTION
Superseed: https://github.com/kenjij/lita-slack/pull/68

Note that enabling the full parsing mode, is not 100% backward compatible. People that were formatting their message for the real time api will have to stop, e.g. `<@U0348FF3M|byroot>` becomes just `@byroot`.

If you absolutely want to preserve 100% the backward compatibility, then we can make the parse mode configurable, and default to `none`.

@jimmycuadra @ajrkerr for review please.
