### PR TITLE
Add a `Reaction < Message` class to handle additon/removal of reactions

### DIFF
--- a/lib/lita/adapters/slack/reaction.rb
+++ b/lib/lita/adapters/slack/reaction.rb
@@ -1,0 +1,20 @@
+module Lita
+  module Adapters
+    class Slack < Adapter
+      class Reaction < Message
+        # name and item attributes of the Reaction - following Slack convention
+        attr_reader :name, :item, :event
+
+        # treat name of Reaction equivalent to body of Message
+        alias_method :body, :name
+
+        def initialize(robot, name, item, source, event)
+          @item = item
+          @name = name
+          @event = event
+          super(robot, body, source)
+        end
+      end
+    end
+  end
+end

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -583,6 +583,78 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
       end
     end
 
+    context "with a reaction_added message" do
+      let(:data) do
+        {
+          "type" => "reaction_added",
+          "user" => "U023BECGF",
+          "item"=>{"type"=>"message", "channel"=>"C2147483705", "ts"=>"1234567.000008"},
+          "reaction"=>"+1",
+          "event_ts"=>"1234.5678"
+        }
+      end
+      let(:reaction) { instance_double('Lita::Adapters::Slack::Reaction', extensions: {}) }
+      let(:source) { instance_double('Lita::Source') }
+      let(:user) { instance_double('Lita::User', id: 'U023BECGF') }
+
+      before do
+        allow(Lita::User).to receive(:find_by_id).and_return(user)
+        allow(Lita::Source).to receive(:new).with(
+            user: user,
+            room: "C2147483705"
+          ).and_return(source)
+        allow(Lita::Adapters::Slack::Reaction).to receive(:new)
+            .with(robot, "+1", {"type"=>"message", "channel"=>"C2147483705", "ts"=>"1234567.000008"}, source, "added").and_return(reaction)
+        allow(robot).to receive(:receive).with(reaction)
+      end
+
+      it "dispatches the added reaction to Lita" do
+        expect(robot).to receive(:receive).with(reaction)
+        subject.handle
+      end
+
+      it "saves the timestamp in extensions" do
+        subject.handle
+        expect(reaction.extensions[:slack][:timestamp]).to eq("1234.5678")
+      end
+    end
+
+    context "with a reaction_removed message" do
+      let(:data) do
+        {
+          "type" => "reaction_removed",
+          "user" => "U023BECGF",
+          "item"=>{"type"=>"message", "channel"=>"C2147483705", "ts"=>"1234567.000008"},
+          "reaction"=>"+1",
+          "event_ts"=>"1234.5678"
+        }
+      end
+      let(:reaction) { instance_double('Lita::Adapters::Slack::Reaction', extensions: {}) }
+      let(:source) { instance_double('Lita::Source') }
+      let(:user) { instance_double('Lita::User', id: 'U023BECGF') }
+
+      before do
+        allow(Lita::User).to receive(:find_by_id).and_return(user)
+        allow(Lita::Source).to receive(:new).with(
+            user: user,
+            room: "C2147483705"
+          ).and_return(source)
+        allow(Lita::Adapters::Slack::Reaction).to receive(:new)
+            .with(robot, "+1", {"type"=>"message", "channel"=>"C2147483705", "ts"=>"1234567.000008"}, source, "removed").and_return(reaction)
+        allow(robot).to receive(:receive).with(reaction)
+      end
+
+      it "dispatches the removed reaction to Lita" do
+        expect(robot).to receive(:receive).with(reaction)
+        subject.handle
+      end
+
+      it "saves the timestamp in extensions" do
+        subject.handle
+        expect(reaction.extensions[:slack][:timestamp]).to eq("1234.5678")
+      end
+    end
+
     context "with an unknown message" do
       let(:data) { { "type" => "???" } }
 


### PR DESCRIPTION
This PR handles the only two available Slack API events for _reactions_ : `reaction_added` and `reaction_removed`. 
A new class, `Reaction < Message` has been included with additional attributes `name` and `item` (following Slack convention for _reactions_ - `name` contains the _type of reaction_ and `item` contains information on the _item reacted to_). An `event` attribute distinguishes between _addition_ and _removal_ of reactions. 
In `message_handler.rb`, a `handle_reaction` method (very similar to the `handle_message` method) initialises and dispatches `Reaction` objects. Continuing on https://github.com/litaio/lita-slack/pull/75, the timestamp of the reaction is saved in the `extensions` hash.
Relevant specs are also included.