### PR TITLE
Trigger slack_reaction_added/removed events

### DIFF
--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -16,6 +16,8 @@ module Lita
             handle_hello
           when "message"
             handle_message
+          when "reaction_added", "reaction_removed"
+            handle_reaction
           when "user_change", "team_join"
             handle_user_change
           when "bot_added", "bot_changed"
@@ -158,6 +160,26 @@ module Lita
           return if from_self?(user)
 
           dispatch_message(user)
+        end
+
+        def handle_reaction
+          log.debug "#{type} event received from Slack"
+
+          # find or create user
+          user = User.find_by_id(data["user"]) || User.create(data["user"])
+
+          # avoid processing reactions added/removed by self
+          return if from_self?(user)
+
+          # build a payload following slack convention for reactions
+          payload = { user: user, name: data["reaction"], item: data["item"], event_ts: data["event_ts"] }
+
+          # trigger the appropriate slack reaction event
+          if type == "reaction_added"
+            robot.trigger(:slack_reaction_added, payload)
+          elsif type == "reaction_removed"
+            robot.trigger(:slack_reaction_removed, payload)
+          end
         end
 
         def handle_unknown

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -175,11 +175,7 @@ module Lita
           payload = { user: user, name: data["reaction"], item: data["item"], event_ts: data["event_ts"] }
 
           # trigger the appropriate slack reaction event
-          if type == "reaction_added"
-            robot.trigger(:slack_reaction_added, payload)
-          elsif type == "reaction_removed"
-            robot.trigger(:slack_reaction_removed, payload)
-          end
+          robot.trigger("slack_#{type}".to_sym, payload)
         end
 
         def handle_unknown

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -583,6 +583,54 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
       end
     end
 
+    context "with a reaction_added message" do
+      let(:data) do
+        {
+          "type" => "reaction_added",
+          "user" => "U023BECGF",
+          "item"=>{"type"=>"message", "channel"=>"C2147483705", "ts"=>"1234567.000008"},
+          "reaction"=>"+1",
+          "event_ts"=>"1234.5678"
+        }
+      end
+      let(:user) { instance_double('Lita::User', id: 'U023BECGF') }
+      let(:payload) { {user: user, name: data["reaction"], item: data["item"], event_ts: data["event_ts"]} }
+
+      before do
+        allow(Lita::User).to receive(:find_by_id).and_return(user)
+        allow(robot).to receive(:trigger).with(:slack_reaction_added, payload)
+      end
+
+      it "triggers the slack_reaction_added event with the correct payload" do
+        expect(robot).to receive(:trigger).with(:slack_reaction_added, payload)
+        subject.handle
+      end
+    end
+
+    context "with a reaction_removed message" do
+      let(:data) do
+        {
+          "type" => "reaction_removed",
+          "user" => "U023BECGF",
+          "item"=>{"type"=>"message", "channel"=>"C2147483705", "ts"=>"1234567.000008"},
+          "reaction"=>"+1",
+          "event_ts"=>"1234.5678"
+        }
+      end
+      let(:user) { instance_double('Lita::User', id: 'U023BECGF') }
+      let(:payload) { {user: user, name: data["reaction"], item: data["item"], event_ts: data["event_ts"]} }
+
+      before do
+        allow(Lita::User).to receive(:find_by_id).and_return(user)
+        allow(robot).to receive(:trigger).with(:slack_reaction_removed, payload)
+      end
+
+      it "triggers the slack_reaction_removed event with the correct payload" do
+        expect(robot).to receive(:trigger).with(:slack_reaction_removed, payload)
+        subject.handle
+      end
+    end
+
     context "with an unknown message" do
       let(:data) { { "type" => "???" } }
 


### PR DESCRIPTION
Based on recommendations provided as feedback for https://github.com/litaio/lita-slack/pull/78 . `message_handler.rb` has been modified to include a `handle_reaction` method which triggers two new events named `:slack_reaction_added` and `:slack_reaction_removed` with a payload consistent with the slack convention for reaction objects. 
Two new test cases have also been included in `message_handler_spec.rb` to test event triggering.