### PR TITLE
Added Slack profile back into metadata

### DIFF
--- a/lib/lita/adapters/slack/user_creator.rb
+++ b/lib/lita/adapters/slack/user_creator.rb
@@ -7,8 +7,7 @@ module Lita
           def create_user(slack_user, robot, robot_id)
             User.create(
               slack_user.id,
-              name: real_name(slack_user),
-              mention_name: slack_user.name
+              construct_metadata(slack_user)
             )
 
             update_robot(robot, slack_user) if slack_user.id == robot_id
@@ -28,6 +27,18 @@ module Lita
           def update_robot(robot, slack_user)
             robot.name = slack_user.real_name
             robot.mention_name = slack_user.name
+          end
+
+          def construct_metadata(slack_user)
+            metadata = slack_user.metadata['profile'] || {}
+            metadata.merge!({ name: real_name(slack_user), mention_name: slack_user.name })
+            compact metadata
+          end
+
+          # The future user.save will discard empty Arrays
+          # Redis requires an even number of arguments for hmset
+          def compact(hash)
+            hash.reject { |_, v| v.is_a?(Array) ? v.compact.empty? : false }
           end
         end
       end


### PR DESCRIPTION
Fixes hmset issue in #57. The hmset method expects an even length Array. Any empty array in the metadata hash will be ejected when it's flattened, which results in an uneven Array.