### PR TITLE
Fix MessageHandler#dispatch_message to include the channel name

### DIFF
--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -111,7 +111,8 @@ module Lita
         end
 
         def dispatch_message(user)
-          source = Source.new(user: user, room: channel)
+          room = Room.find_by_id(channel)
+          source = Source.new(user: user, room: room || channel)
           source.private_message! if channel && channel[0] == "D"
           message = Message.new(robot, body, source)
           message.command! if source.private_message?

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -37,12 +37,14 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
       let(:message) { instance_double('Lita::Message', command!: false, extensions: {}) }
       let(:source) { instance_double('Lita::Source', private_message?: false) }
       let(:user) { instance_double('Lita::User', id: 'U023BECGF') }
+      let(:room) { instance_double('Lita::Room', id: 'C2147483705', name: 'general', metadata: {'name' => 'general'}) }
 
       before do
         allow(Lita::User).to receive(:find_by_id).and_return(user)
+        allow(Lita::Room).to receive(:find_by_id).and_return(room)
         allow(Lita::Source).to receive(:new).with(
           user: user,
-          room: "C2147483705"
+          room: room,
         ).and_return(source)
         allow(Lita::Message).to receive(:new).with(robot, "Hello", source).and_return(message)
         allow(robot).to receive(:receive).with(message)


### PR DESCRIPTION
Before:

```ruby
>> response.message.source.room_object.name
"C03R55SKJ"
```

After:
>> response.message.source.room_object.name
"general"


@etiennebarrie @jimmycuadra for review please.