### PR TITLE
Implemented roster method for Adapter

### DIFF
--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -28,6 +28,13 @@ module Lita
         rtm_connection.run
       end
 
+      # Returns UID(s) in an Array or String for:
+      # Channels, MPIMs, IMs
+      def roster(target)
+        api = API.new(config)
+        room_roster target.id, api
+      end
+
       def send_messages(target, strings)
         api = API.new(config)
         api.send_messages(channel_for(target), strings)
@@ -55,6 +62,36 @@ module Lita
           rtm_connection.im_for(target.user.id)
         else
           target.room
+        end
+      end
+
+      def channel_roster(room_id, api)
+        response = api.channels_info room_id
+        response['channel']['members']
+      end
+
+      # Returns the members of a mpim, but only can do so if it's a member
+      def mpim_roster(room_id, api)
+        response = api.mpim_list
+        mpim = response['groups'].select { |hash| hash['id'].eql? room_id }.first
+        mpim.nil? ? [] : mpim['members']
+      end
+
+      # Returns the user of an im
+      def im_roster(room_id, api)
+        response = api.mpim_list
+        im = response['ims'].select { |hash| hash['id'].eql? room_id }.first
+        im.nil? ? '' : im['user']
+      end
+
+      def room_roster(room_id, api)
+        case room_id
+        when /^C0/
+          channel_roster room_id, api
+        when /^G0/
+          mpim_roster room_id, api
+        when /^D0/
+          im_roster room_id, api
         end
       end
     end

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -70,6 +70,13 @@ module Lita
         response['channel']['members']
       end
 
+      # Returns the members of a group, but only can do so if it's a member
+      def group_roster(room_id, api)
+        response = api.groups_list
+        group = response['groups'].select { |hash| hash['id'].eql? room_id }.first
+        group.nil? ? [] : group['members']
+      end
+
       # Returns the members of a mpim, but only can do so if it's a member
       def mpim_roster(room_id, api)
         response = api.mpim_list
@@ -89,7 +96,9 @@ module Lita
         when /^C0/
           channel_roster room_id, api
         when /^G0/
-          mpim_roster room_id, api
+          # Groups & MPIMs have the same room ID pattern, check both if needed
+          roster = group_roster room_id, api
+          roster.empty? ? mpim_roster(room_id, api) : roster
         when /^D0/
           im_roster room_id, api
         end

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -29,6 +29,10 @@ module Lita
           call_api("channels.list")
         end
 
+        def groups_list
+          call_api("groups.list")
+        end
+
         def mpim_list
           call_api("mpim.list")
         end

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -21,6 +21,22 @@ module Lita
           SlackIM.new(response_data["channel"]["id"], user_id)
         end
 
+        def channels_info(channel_id)
+          call_api("channels.info", channel: channel_id)
+        end
+
+        def channels_list
+          call_api("channels.list")
+        end
+
+        def mpim_list
+          call_api("mpim.list")
+        end
+
+        def im_list
+          call_api("im.list")
+        end
+
         def send_attachments(room_or_user, attachments)
           call_api(
             "chat.postMessage",

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -174,6 +174,60 @@ describe Lita::Adapters::Slack::API do
     end
   end
 
+  describe "#groups_list" do
+    let(:channel_id) { 'G024BE91L' }
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.post('https://slack.com/api/groups.list', token: token) do
+          [http_status, {}, http_response]
+        end
+      end
+    end
+
+    describe "with a successful response" do
+      let(:http_response) do
+        MultiJson.dump({
+            ok: true,
+            groups: [{
+                id: 'G024BE91L'
+            }]
+        })
+      end
+
+      it "returns a response with groupss Channel ID's" do
+        response = subject.groups_list
+
+        expect(response['groups'].first['id']).to eq(channel_id)
+      end
+    end
+
+    describe "with a Slack error" do
+      let(:http_response) do
+        MultiJson.dump({
+          ok: false,
+          error: 'invalid_auth'
+        })
+      end
+
+      it "raises a RuntimeError" do
+        expect { subject.groups_list }.to raise_error(
+          "Slack API call to groups.list returned an error: invalid_auth."
+        )
+      end
+    end
+
+    describe "with an HTTP error" do
+      let(:http_status) { 422 }
+      let(:http_response) { '' }
+
+      it "raises a RuntimeError" do
+        expect { subject.groups_list }.to raise_error(
+          "Slack API call to groups.list failed with status code 422."
+        )
+      end
+    end
+  end
+
   describe "#mpim_list" do
     let(:channel_id) { 'G024BE91L' }
     let(:stubs) do

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -66,6 +66,222 @@ describe Lita::Adapters::Slack::API do
     end
   end
 
+  describe "#channels_info" do
+    let(:channel_id) { 'C024BE91L' }
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.post('https://slack.com/api/channels.info', token: token, channel: channel_id) do
+          [http_status, {}, http_response]
+        end
+      end
+    end
+
+    describe "with a successful response" do
+      let(:http_response) do
+        MultiJson.dump({
+            ok: true,
+            channel: {
+                id: 'C024BE91L'
+            }
+        })
+      end
+
+      it "returns a response with the Channel's ID" do
+        response = subject.channels_info(channel_id)
+
+        expect(response['channel']['id']).to eq(channel_id)
+      end
+    end
+
+    describe "with a Slack error" do
+      let(:http_response) do
+        MultiJson.dump({
+          ok: false,
+          error: 'channel_not_found'
+        })
+      end
+
+      it "raises a RuntimeError" do
+        expect { subject.channels_info(channel_id) }.to raise_error(
+          "Slack API call to channels.info returned an error: channel_not_found."
+        )
+      end
+    end
+
+    describe "with an HTTP error" do
+      let(:http_status) { 422 }
+      let(:http_response) { '' }
+
+      it "raises a RuntimeError" do
+        expect { subject.channels_info(channel_id) }.to raise_error(
+          "Slack API call to channels.info failed with status code 422."
+        )
+      end
+    end
+  end
+
+  describe "#channels_list" do
+    let(:channel_id) { 'C024BE91L' }
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.post('https://slack.com/api/channels.list', token: token) do
+          [http_status, {}, http_response]
+        end
+      end
+    end
+
+    describe "with a successful response" do
+      let(:http_response) do
+        MultiJson.dump({
+            ok: true,
+            channel: [{
+                id: 'C024BE91L'
+            }]
+        })
+      end
+
+      it "returns a response with the Channel's ID" do
+        response = subject.channels_list
+
+        expect(response['channel'].first['id']).to eq(channel_id)
+      end
+    end
+
+    describe "with a Slack error" do
+      let(:http_response) do
+        MultiJson.dump({
+          ok: false,
+          error: 'invalid_auth'
+        })
+      end
+
+      it "raises a RuntimeError" do
+        expect { subject.channels_list }.to raise_error(
+          "Slack API call to channels.list returned an error: invalid_auth."
+        )
+      end
+    end
+
+    describe "with an HTTP error" do
+      let(:http_status) { 422 }
+      let(:http_response) { '' }
+
+      it "raises a RuntimeError" do
+        expect { subject.channels_list }.to raise_error(
+          "Slack API call to channels.list failed with status code 422."
+        )
+      end
+    end
+  end
+
+  describe "#mpim_list" do
+    let(:channel_id) { 'G024BE91L' }
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.post('https://slack.com/api/mpim.list', token: token) do
+          [http_status, {}, http_response]
+        end
+      end
+    end
+
+    describe "with a successful response" do
+      let(:http_response) do
+        MultiJson.dump({
+            ok: true,
+            groups: [{
+                id: 'G024BE91L'
+            }]
+        })
+      end
+
+      it "returns a response with MPIMs Channel ID's" do
+        response = subject.mpim_list
+
+        expect(response['groups'].first['id']).to eq(channel_id)
+      end
+    end
+
+    describe "with a Slack error" do
+      let(:http_response) do
+        MultiJson.dump({
+          ok: false,
+          error: 'invalid_auth'
+        })
+      end
+
+      it "raises a RuntimeError" do
+        expect { subject.mpim_list }.to raise_error(
+          "Slack API call to mpim.list returned an error: invalid_auth."
+        )
+      end
+    end
+
+    describe "with an HTTP error" do
+      let(:http_status) { 422 }
+      let(:http_response) { '' }
+
+      it "raises a RuntimeError" do
+        expect { subject.mpim_list }.to raise_error(
+          "Slack API call to mpim.list failed with status code 422."
+        )
+      end
+    end
+  end
+
+   describe "#im_list" do
+    let(:channel_id) { 'D024BFF1M' }
+    let(:stubs) do
+      Faraday::Adapter::Test::Stubs.new do |stub|
+        stub.post('https://slack.com/api/im.list', token: token) do
+          [http_status, {}, http_response]
+        end
+      end
+    end
+
+    describe "with a successful response" do
+      let(:http_response) do
+        MultiJson.dump({
+            ok: true,
+            ims: [{
+                id: 'D024BFF1M'
+            }]
+        })
+      end
+
+      it "returns a response with IMs Channel ID's" do
+        response = subject.im_list
+
+        expect(response['ims'].first['id']).to eq(channel_id)
+      end
+    end
+
+    describe "with a Slack error" do
+      let(:http_response) do
+        MultiJson.dump({
+          ok: false,
+          error: 'invalid_auth'
+        })
+      end
+
+      it "raises a RuntimeError" do
+        expect { subject.im_list }.to raise_error(
+          "Slack API call to im.list returned an error: invalid_auth."
+        )
+      end
+    end
+
+    describe "with an HTTP error" do
+      let(:http_status) { 422 }
+      let(:http_response) { '' }
+
+      it "raises a RuntimeError" do
+        expect { subject.im_list }.to raise_error(
+          "Slack API call to im.list failed with status code 422."
+        )
+      end
+    end
+  end
+
   describe "#send_attachments" do
     let(:attachment) do
       Lita::Adapters::Slack::Attachment.new(attachment_text)

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -1,5 +1,5 @@
-
 require "spec_helper"
+
 describe Lita::Adapters::Slack, lita: true do
   subject { described_class.new(robot) }
 
@@ -45,6 +45,73 @@ describe Lita::Adapters::Slack, lita: true do
 
       subject.run
       subject.run
+    end
+  end
+
+  describe "#roster" do
+    describe "via the Web API, retrieving the roster for a channel" do
+      let(:room_source) { Lita::Source.new(room: 'C024BE91L') }
+      let(:response) do
+        {
+          ok: true,
+          channel: {
+              members: ['C024BE91L']
+          }
+        }
+      end
+      let(:api) { instance_double('Lita::Adapters::Slack::API') }
+
+      before do
+        allow(Lita::Adapters::Slack::API).to receive(:new).with(subject.config).and_return(api)
+      end
+
+      it "returns UID(s)" do
+        expect(subject).to receive(:channel_roster).with(room_source.room_object.id, api)
+
+        subject.roster(room_source.room_object)
+      end
+    end
+
+    describe "via the Web API, retrieving the roster for a mpim channel" do
+      let(:room_source) { Lita::Source.new(room: 'G024BE91L') }
+      let(:response) do
+        {
+          ok: true,
+          groups: [{ id: 'G024BE91L' }]
+        }
+      end
+      let(:api) { instance_double('Lita::Adapters::Slack::API') }
+
+      before do
+        allow(Lita::Adapters::Slack::API).to receive(:new).with(subject.config).and_return(api)
+      end
+
+      it "returns UID(s)" do
+        expect(subject).to receive(:mpim_roster).with(room_source.room_object.id, api)
+
+        subject.roster(room_source.room_object)
+      end
+    end
+
+    describe "via the Web API, retrieving the roster for an im channel" do
+      let(:room_source) { Lita::Source.new(room: 'D024BFF1M') }
+      let(:response) do
+        {
+          ok: true,
+          ims: [{ id: 'D024BFF1M' }]
+        }
+      end
+      let(:api) { instance_double('Lita::Adapters::Slack::API') }
+
+      before do
+        allow(Lita::Adapters::Slack::API).to receive(:new).with(subject.config).and_return(api)
+      end
+
+      it "returns UID" do
+        expect(subject).to receive(:im_roster).with(room_source.room_object.id, api)
+
+        subject.roster(room_source.room_object)
+      end
     end
   end
 

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -72,7 +72,7 @@ describe Lita::Adapters::Slack, lita: true do
       end
     end
 
-    describe "via the Web API, retrieving the roster for a mpim channel" do
+    describe "via the Web API, retrieving the roster for a group/mpim channel" do
       let(:room_source) { Lita::Source.new(room: 'G024BE91L') }
       let(:response) do
         {
@@ -87,7 +87,8 @@ describe Lita::Adapters::Slack, lita: true do
       end
 
       it "returns UID(s)" do
-        expect(subject).to receive(:mpim_roster).with(room_source.room_object.id, api)
+        expect(subject).to receive(:group_roster).with(room_source.room_object.id, api).and_return(%q{})
+        expect(subject).to receive(:mpim_roster).with(room_source.room_object.id, api).and_return(%q{G024BE91L})
 
         subject.roster(room_source.room_object)
       end


### PR DESCRIPTION
Fulfilling this request litaio/lita#69 for lita-slack. 

`robot.roster room_id` will now return user UID(s) in an Array or String for Channels, Groups, MPIMs, & IMs.