### PR TITLE
config.postMessage instead of config.parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,12 @@ Lita.configure do |config|
   config.robot.adapter = :slack
   config.robot.admins = ["U012A3BCD"]
   config.adapters.slack.token = "abcd-1234567890-hWYd21AmMH2UHAkx29vb5c1Y"
-  config.adapters.slack.parse = "full" # See https://api.slack.com/docs/formatting#parsing_modes
+
+  # Slack parsing mode options, See https://api.slack.com/docs/formatting#parsing_modes
+  # config.adapters.slack.parse = "full"
+  config.adapters.slack.link_names = true
+  config.adapters.slack.unfurl_links = false
+  config.adapters.slack.unfurl_media = false
 end
 ```
 

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -9,7 +9,10 @@ module Lita
       # Required configuration attributes.
       config :token, type: String, required: true
       config :proxy, type: String
-      config :parse, type: String
+      config :parse, type: [String]
+      config :link_names, type: [true, false]
+      config :unfurl_links, type: [true, false]
+      config :unfurl_media, type: [true, false]
 
       # Provides an object for Slack-specific features.
       def chat_service

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -13,6 +13,11 @@ module Lita
         def initialize(config, stubs = nil)
           @config = config
           @stubs = stubs
+          @post_message_config = {}
+          @post_message_config[:parse] = config.parse unless config.parse.nil?
+          @post_message_config[:link_names] = config.link_names ? 1 : 0 unless config.link_names.nil?
+          @post_message_config[:unfurl_links] = config.unfurl_links unless config.unfurl_links.nil?
+          @post_message_config[:unfurl_media] = config.unfurl_media unless config.unfurl_media.nil?
         end
 
         def im_open(user_id)
@@ -33,10 +38,10 @@ module Lita
         def send_messages(channel_id, messages)
           call_api(
             "chat.postMessage",
+            **post_message_config,
             as_user: true,
             channel: channel_id,
             text: messages.join("\n"),
-            parse: config.parse,
           )
         end
 
@@ -61,6 +66,7 @@ module Lita
 
         attr_reader :stubs
         attr_reader :config
+        attr_reader :post_message_config
 
         def call_api(method, post_data = {})
           response = connection.post(

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -191,7 +191,6 @@ describe Lita::Adapters::Slack::API do
           as_user: true,
           channel: room,
           text: messages.join("\n"),
-          parse: nil,
         ) do
           [http_status, {}, http_response]
         end
@@ -200,6 +199,33 @@ describe Lita::Adapters::Slack::API do
 
     context "with a simple text attachment" do
       it "sends the attachment" do
+        response = subject.send_messages(room, messages)
+
+        expect(response['ok']).to be(true)
+      end
+    end
+
+    context "with configuration" do
+      before do
+        allow(config).to receive(:link_names).and_return(true)
+      end
+
+      def stubs(postMessage_options = {})
+        Faraday::Adapter::Test::Stubs.new do |stub|
+          stub.post(
+            "https://slack.com/api/chat.postMessage",
+            token: token,
+            link_names: 1,
+            as_user: true,
+            channel: room,
+            text: messages.join("\n"),
+          ) do
+            [http_status, {}, http_response]
+          end
+        end
+      end
+
+      it "sends the message with configuration" do
         response = subject.send_messages(room, messages)
 
         expect(response['ok']).to be(true)


### PR DESCRIPTION
Instead of having a single `parse` configuration, this allows to set options to be merged in each call to `chat.postMessage` when using the Web API.

This lets us use different options than `parse: full` that we wanted to use, namely `link_names: 1` to parse `@users` and `#channels`, all the while letting URLs like `<https://www.lita.io/|Lita>` be parsed by Slack.

cc @byroot 