### PR TITLE
Make error messages more verbose.

### DIFF
--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -79,7 +79,7 @@ module Lita
 
         def parse_response(response, method)
           unless response.success?
-            raise "Slack API call to #{method} failed with status code #{response.status}."
+            raise "Slack API call to #{method} failed with status code #{response.status}: '#{response.body}'. Headers: #{response.headers}"
           end
 
           MultiJson.load(response.body)

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -60,7 +60,7 @@ describe Lita::Adapters::Slack::API do
 
       it "raises a RuntimeError" do
         expect { subject.im_open(user_id) }.to raise_error(
-          "Slack API call to im.open failed with status code 422."
+          "Slack API call to im.open failed with status code 422: ''. Headers: {}"
         )
       end
     end
@@ -173,7 +173,7 @@ describe Lita::Adapters::Slack::API do
 
       it "raises a RuntimeError" do
         expect { subject.send_attachments(room, [attachment]) }.to raise_error(
-          "Slack API call to chat.postMessage failed with status code 422."
+          "Slack API call to chat.postMessage failed with status code 422: ''. Headers: {}"
         )
       end
     end
@@ -231,7 +231,7 @@ describe Lita::Adapters::Slack::API do
 
       it "raises a RuntimeError" do
         expect { subject.set_topic(channel, topic) }.to raise_error(
-          "Slack API call to channels.setTopic failed with status code 422."
+          "Slack API call to channels.setTopic failed with status code 422: ''. Headers: {}"
         )
       end
     end


### PR DESCRIPTION
So we don't have to rely on our own forks of the adapter to make sense of Slack's error messages while debugging.