### PR TITLE
Fix and simplify MessageHandler#from_self

### DIFF
--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -123,11 +123,7 @@ module Lita
         end
 
         def from_self?(user)
-          if data["subtype"] == "bot_message"
-            robot_user = User.find_by_name(robot.name)
-
-            robot_user && robot_user.id == user.id
-          end
+          user.id == robot_id
         end
 
         def handle_bot_change

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -477,15 +477,8 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
       let(:data) do
         {
           "type" => "message",
-          "subtype" => "bot_message"
+          "user" => robot_id
         }
-      end
-      let(:user) { instance_double('Lita::User', id: 12345) }
-
-      before do
-        # TODO: This probably shouldn't be tested with stubs.
-        allow(Lita::User).to receive(:find_by_id).and_return(user)
-        allow(Lita::User).to receive(:find_by_name).and_return(user)
       end
 
       it "does not dispatch the message to Lita" do


### PR DESCRIPTION
We were having a lot of `cannot_dm_bot` errors in production. After some investigation it occured that our Lita bot was seeing it's own responses when you were talking to it via direct messages.

I don't know if the Slack API changed and the `subtype` isn't sent anymore, of it the doc is lying and it was never sent. However it's clearly missing today.

Here's what the payload look like for a bot seeing itself talking:

```ruby
{"type"=>"message", "user"=>"U0MK1JVGX", "text"=>":pong:", "bot_id"=>"B0MK2975E", "user_team"=>"T024G4BGQ", "team"=>"T024G4BGQ", "channel"=>"D0MK2RZGA", "ts"=>"1461946141.000024"}
```

Also the current code use `User.find_by_name(robot.name)`, so the config absolutely need to be accurate otherwise Lita can't identify itself.

The new code is way more robust in my opinion.

@jimmycuadra for review please.

cc @etiennebarrie @wvanbergen