### PR TITLE
Add API to send messages with options

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ gem "lita-slack"
 ### Optional attributes
 
 * `proxy` (String) – Specify a HTTP proxy URL. (e.g. "http://squid.example.com:3128")
-* `default_message_arguments` - Default message arguments for all messages sent by Lita to Slack. Defaults to `{ as_user: true }`. See [below](#message_arguments) for more explanation. Overrides any values in `link_names`, `parse`, `unfurl_links` or `unfurl_media`. NOTE: if you override this and want `as_user: true`, you will need to set it in your own `default_message_arguments` value explicitly.
 * `link_names` (Boolean) – Set to `true` to turn all Slack usernames in messages sent by Lita into links.
 * `parse` (String) – Specify the parsing mode. See https://api.slack.com/docs/formatting#parsing_modes.
 * `unfurl_links` (Boolean) – Set to `true` to automatically add previews for all links in messages sent by Lita.
@@ -65,61 +64,7 @@ Lita will join your default channel after initial setup. To have it join additio
 
 ## Chat service API
 
-lita-slack supports Lita 4.6's chat service API for Slack-specific functionality. You can access this API object by calling the `Lita::Robot#chat_service`. See the API docs for `Lita::Adapters::Slack::ChatService` for details about the provided methods.
-
-## Messages and Formatting
-
-To promote cross-chat-service bots, messages sent to Slack via the Lita API do
-not allow Slack's custom formatting (for example, links like `<https://google.com|Google>`) that will not work in other services.
-
-The message arguments passed to the Slack API determine how your message and
-attachment text is treated. By default, only `as_user: true` is sent to the API,
-which means link formatting like `<https://google.com|Google>` is disregarded, and
-media URLs like youtube and imgur will be auto-unfurled and have the videos/images
-shown directly in the channel, but other URLs like Github and Slack will not be
-unfurled.
-
-In order to take full advantage of Slack, you can call
-`robot.chat_service.send_message(room_or_user[, "message"], attachments: [...], **message_arguments)`. Message arguments are the same as the [chat.postMessage API](https://api.slack.com/methods/chat.postMessage#arguments), and include:
-
-| Argument      | Description                                                  |
-|---------------|--------------------------------------------------------------|
-| `as_user`     | Determines whether the bot posts as an authenticated user. If set to `true`, `username`, `icon_emoji` and `icon_url` on the message are ignored and the actual bot user's username, icon_emoji and icon_url are used. Posting as a bot can be useful if you want to change the bot's icon on a per-message basis. If this is not set, Slack will guess a value for you. (If you did not set `default_message_arguments`, `as_user` will default to `true`.)
-| `username`     | The display name for the user (not the `@nickname`, the full name).
-| `icon_emoji`   | An emoji for the Bot's post (e.g. `:lol:`).
-| `icon_url`     | The URL to an image for the Bot's icon.
-| `parse`        | Governs what formatting you can put in your messages. `none` lets you fully format your message [the Slack way](https://api.slack.com/docs/formatting) (so `<https://google.com|Google>` prints out as `Google`). `full` does not honor Slack formatting, escaping characters in the message exactly as you sent them (so `<https://google.com|Google>` prints out as `<https://google.com|Google>`), and turns `unfurl_links` on.
-| `link_names`   | When set to 1, tells Slack to find and linkify channel and usernames such as @user and #channel. Slack has this off by default.
-| `unfurl_media` | When set to `true`, Slack will find URLs in your message that point to images, video, sound, etc. and [generate attachments for them](https://api.slack.com/docs/unfurling) automatically. Slack defaults this to `true`.
-| `unfurl_links` | When set to `true`, Slack will find URLs in your message that point to non-media stuff (like Google or Github) and generate an attachment automatically for them. Slack defaults this to `false`.
-
-Because message arguments are sent without processing to Slack, when the
-Slack API adds new arguments and argument values in the future, they will be
-automatically supported. Any options you do not specify will not be passed to
-Slack, and Slack will use its own defaults for them.
-
-If you want all messages to have the same options by default, you can set any of the above properties by setting them in `config.default_message_arguments`. For example, this will cause channel names to be linkified in all messages:
-
-```ruby
-config.adapters.slack.default_message_arguments = { as_user: true, link_names: 1 }
-```
-
-### Attachments
-
-The `post_slack_message` method accepts attachments using the [Slack attachment structure](https://api.slack.com/docs/attachments):
-
-```
-robot.chat_service.post_slack_message(room_or_user, attachments: [
-    {
-      pretext: "The build is broke!",
-      text: "your build!\nit\nis\nbroken.\ncould it be worse?\n... probably",
-      color: "danger",
-      thumb_url: "https://thumbnails.com/brokenbuild.jpg"
-    }
-])
-```
-
-Like `message_arguments`, attachments are passed verbatim to the Slack API.
+lita-slack supports Lita 4.6's chat service API for Slack-specific functionality. You can access this API object by calling the `Lita::Robot#chat_service`. See the API docs for `Lita::Adapters::Slack::ChatService` for details about the provided methods, which include attachments, rich formatting, and updating and deleting of methods.
 
 ## API documentation
 

--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ gem "lita-slack"
 
 ### Optional attributes
 
+* `proxy` (String) – Specify a HTTP proxy URL. (e.g. "http://squid.example.com:3128")
+* `default_message_arguments` - Default message arguments for all messages sent by Lita to Slack. Defaults to `{ as_user: true }`. See [below](#message_arguments) for more explanation. Overrides any values in `link_names`, `parse`, `unfurl_links` or `unfurl_media`. NOTE: if you override this and want `as_user: true`, you will need to set it in your own `default_message_arguments` value explicitly.
 * `link_names` (Boolean) – Set to `true` to turn all Slack usernames in messages sent by Lita into links.
 * `parse` (String) – Specify the parsing mode. See https://api.slack.com/docs/formatting#parsing_modes.
-* `proxy` (String) – Specify a HTTP proxy URL. (e.g. "http://squid.example.com:3128")
 * `unfurl_links` (Boolean) – Set to `true` to automatically add previews for all links in messages sent by Lita.
 * `unfurl_media` (Boolean) – Set to `false` to prevent automatic previews for media files in messages sent by Lita.
 
@@ -65,6 +66,60 @@ Lita will join your default channel after initial setup. To have it join additio
 ## Chat service API
 
 lita-slack supports Lita 4.6's chat service API for Slack-specific functionality. You can access this API object by calling the `Lita::Robot#chat_service`. See the API docs for `Lita::Adapters::Slack::ChatService` for details about the provided methods.
+
+## Messages and Formatting
+
+To promote cross-chat-service bots, messages sent to Slack via the Lita API do
+not allow Slack's custom formatting (for example, links like `<https://google.com|Google>`) that will not work in other services.
+
+The message arguments passed to the Slack API determine how your message and
+attachment text is treated. By default, only `as_user: true` is sent to the API,
+which means link formatting like `<https://google.com|Google>` is disregarded, and
+media URLs like youtube and imgur will be auto-unfurled and have the videos/images
+shown directly in the channel, but other URLs like Github and Slack will not be
+unfurled.
+
+In order to take full advantage of Slack, you can call
+`robot.chat_service.send_message(room_or_user[, "message"], attachments: [...], **message_arguments)`. Message arguments are the same as the [chat.postMessage API](https://api.slack.com/methods/chat.postMessage#arguments), and include:
+
+| Argument      | Description                                                  |
+|---------------|--------------------------------------------------------------|
+| `as_user`     | Determines whether the bot posts as an authenticated user. If set to `true`, `username`, `icon_emoji` and `icon_url` on the message are ignored and the actual bot user's username, icon_emoji and icon_url are used. Posting as a bot can be useful if you want to change the bot's icon on a per-message basis. If this is not set, Slack will guess a value for you. (If you did not set `default_message_arguments`, `as_user` will default to `true`.)
+| `username`     | The display name for the user (not the `@nickname`, the full name).
+| `icon_emoji`   | An emoji for the Bot's post (e.g. `:lol:`).
+| `icon_url`     | The URL to an image for the Bot's icon.
+| `parse`        | Governs what formatting you can put in your messages. `none` lets you fully format your message [the Slack way](https://api.slack.com/docs/formatting) (so `<https://google.com|Google>` prints out as `Google`). `full` does not honor Slack formatting, escaping characters in the message exactly as you sent them (so `<https://google.com|Google>` prints out as `<https://google.com|Google>`), and turns `unfurl_links` on.
+| `link_names`   | When set to 1, tells Slack to find and linkify channel and usernames such as @user and #channel. Slack has this off by default.
+| `unfurl_media` | When set to `true`, Slack will find URLs in your message that point to images, video, sound, etc. and [generate attachments for them](https://api.slack.com/docs/unfurling) automatically. Slack defaults this to `true`.
+| `unfurl_links` | When set to `true`, Slack will find URLs in your message that point to non-media stuff (like Google or Github) and generate an attachment automatically for them. Slack defaults this to `false`.
+
+Because message arguments are sent without processing to Slack, when the
+Slack API adds new arguments and argument values in the future, they will be
+automatically supported. Any options you do not specify will not be passed to
+Slack, and Slack will use its own defaults for them.
+
+If you want all messages to have the same options by default, you can set any of the above properties by setting them in `config.default_message_arguments`. For example, this will cause channel names to be linkified in all messages:
+
+```ruby
+config.adapters.slack.default_message_arguments = { as_user: true, link_names: 1 }
+```
+
+### Attachments
+
+The `post_slack_message` method accepts attachments using the [Slack attachment structure](https://api.slack.com/docs/attachments):
+
+```
+robot.chat_service.post_slack_message(room_or_user, attachments: [
+    {
+      pretext: "The build is broke!",
+      text: "your build!\nit\nis\nbroken.\ncould it be worse?\n... probably",
+      color: "danger",
+      thumb_url: "https://thumbnails.com/brokenbuild.jpg"
+    }
+])
+```
+
+Like `message_arguments`, attachments are passed verbatim to the Slack API.
 
 ## API documentation
 

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -16,7 +16,6 @@ module Lita
       #
       config :token, type: String, required: true
       config :proxy, type: String
-      config :default_message_arguments, type: Hash, default: { as_user: true }
       config :parse, type: [String]
       config :link_names, type: [true, false]
       config :unfurl_links, type: [true, false]
@@ -45,8 +44,14 @@ module Lita
         room_roster target.id
       end
 
-      extend Forwardable
-      def_delegators :chat_service, :send_messages
+      def send_messages(target, strings=[])
+        arguments = {}
+        arguments[:parse] = config.parse unless config.parse.nil?
+        arguments[:link_names] = config.link_names ? 1 : 0 unless config.link_names.nil?
+        arguments[:unfurl_links] = config.unfurl_links unless config.unfurl_links.nil?
+        arguments[:unfurl_media] = config.unfurl_media unless config.unfurl_media.nil?
+        api.call_api("chat.postMessage", channel: api.channel_for(target), text: Array(strings).join("\n"), **arguments)
+      end
 
       def set_topic(target, topic)
         channel = target.room

--- a/lib/lita/adapters/slack/attachment.rb
+++ b/lib/lita/adapters/slack/attachment.rb
@@ -25,6 +25,9 @@ module Lita
             text: text,
           })
         end
+        def to_json(**options)
+          MultiJson.dump(to_hash, **options)
+        end
 
         private
 

--- a/lib/lita/adapters/slack/chat_service.rb
+++ b/lib/lita/adapters/slack/chat_service.rb
@@ -16,20 +16,62 @@ module Lita
           @rtm_connection = rtm_connection
         end
 
-        # @param target [Lita::Room, Lita::User] A room or user object indicating where the
-        #   attachment should be sent.
+        # @param target [Lita::Room, Lita::User] A room or user object
+        #   indicating where the message should be sent.
         # @param strings [String, Array<String>] A string or strings to send as
         #   text.
         # @param message_arguments [Hash] Message arguments to send to Slack,
         #   governing formatting. Arguments correspond to Slack `chat.postMessage`
         #   arguments and will override `config.default_message_arguments`. See
         #   README for a list of known arguments.
-        # @return [void]
+        # @return [Hash] The Slack sent message response, as seen in
+        #   https://api.slack.com/methods/chat.postMessage#response . In
+        #   particular, `response["ts"]` can be used as the `ts` argument to
+        #   update_message and delete_message.
         def send_messages(target, strings=nil, **message_arguments)
           message_arguments[:text] = Array(strings).join("\n") unless strings.nil?
           api.post_message(channel: channel_for(target), **message_arguments)
         end
         alias_method :send_message, :send_messages
+
+        # @param target [Lita::Room, Lita::User] A room or user object
+        #   indicating where the message should be sent.
+        # @param text [String] The message to /me send.
+        # @return [Hash] The Slack sent message response, as seen in
+        #   https://api.slack.com/methods/chat.meMessage#response . In
+        #   particular, `response["ts"]` can be used as the `ts` argument to
+        #   update_message and delete_message.
+        def me_message(target, text)
+          api.me_message(channel: channel_for(target), text: text)
+        end
+
+        # @param target [Lita::Room, Lita::User] A room or user object
+        #   indicating where the message should be sent.
+        # @param ts [Integer] The timestamp of the message (uniquely identifying it).
+        # @param strings [String, Array<String>] A string or strings to send as
+        #   text.
+        # @param arguments [Hash] Message arguments to send to Slack,
+        #   governing formatting. Arguments correspond to Slack `chat.update`
+        #   arguments and will override `config.default_message_arguments`. See
+        #   README for a list of known arguments.
+        # @return [Hash] The Slack sent message response, as seen in
+        #   https://api.slack.com/methods/chat.update#response .
+        def update_message(target, ts, strings=nil, **arguments)
+          arguments[:text] = Array(strings).join("\n") unless strings.nil?
+          api.chat_update(channel: channel_for(target), ts: ts, **arguments)
+        end
+
+        # @param target [Lita::Room, Lita::User] A room or user object
+        #   indicating where the message should be sent.
+        # @param ts [Integer] The timestamp of the message (uniquely identifying it).
+        # @param arguments [Hash] Extra arguments to send to Slack.
+        #   `config.default_message_arguments[:as_user]` will be used if
+        #   `as_user` is not specified.
+        # @return [Hash] The Slack deleted message response, as seen in
+        #   https://api.slack.com/methods/chat.delete#response .
+        def delete_message(target, ts, **arguments)
+          api.chat_delete(channel: channel_for(target), ts: ts, **arguments)
+        end
 
         # @param target [Lita::Source, Lita::Room, Lita::User] A room or user
         #        object indicating where the attachment should be sent.

--- a/lib/lita/adapters/slack/chat_service.rb
+++ b/lib/lita/adapters/slack/chat_service.rb
@@ -16,92 +16,357 @@ module Lita
           @rtm_connection = rtm_connection
         end
 
-        # @param target [Lita::Room, Lita::User] A room or user object
-        #   indicating where the message should be sent.
-        # @param strings [String, Array<String>] A string or strings to send as
-        #   text.
-        # @param message_arguments [Hash] Message arguments to send to Slack,
-        #   governing formatting. Arguments correspond to Slack `chat.postMessage`
-        #   arguments and will override `config.default_message_arguments`. See
-        #   README for a list of known arguments.
-        # @return [Hash] The Slack sent message response, as seen in
-        #   https://api.slack.com/methods/chat.postMessage#response . In
+        #
+        # Send a message to Slack.
+        #
+        # @param target [Lita::Source, Lita::Room, Lita::User, String] A Lita
+        #   source, room or user object, or a Slack channel ID, indicating where
+        #   the message should be sent.
+        # @param text [String] The text of the message. Either text or attachments
+        #   is required.
+        # @param attachments [Array<Hash, Attachment>] A list of attachments to
+        #   the message. Either text or attachments is required. Each attachment
+        #   must be either an attachment object or a Hash of the form specified
+        #   in https://api.slack.com/docs/attachments#attachment_structure.
+        #
+        #   `pretext`, `title`, `text`, field `value` and `footer` are affected
+        #   by `parse` and `link_names`.
+        #
+        #   Markdown is not enabled in any field by default. See the `mrkdwn_in`
+        #   option to control markdown formatting in pretext, text
+        #   and fields. Slack links like `<https://google.com|Google>` are
+        #   *always* enabled in pretext, title, text, field values and footer,
+        #   and never enabled in author_name and field titles. Links in
+        #   attachments are never unfurled.
+        # @option attachments [String] :fallback Required plain-text summary of
+        #   the attachment.
+        # @option attachments [:good, :warning, :danger, String] :color The
+        #   color of the left border of the attachment. good=green,
+        #   warning=yellow, danger=red. Pass `"#<hex>"` for an arbitrary color
+        #   (e.g. `"#439FE0"`).
+        # @option mrkdwn_in [Array<String>] :mrkdwn_in The list of elements with
+        #   markdown in them. Passing `["pretext"]` will enable markdown in
+        #   `pretext` but not in `text`. Possible values include `"pretext"`,
+        #   `"text"` and `"fields"` (which will affect only field values, not
+        #   field titles). This does not affect Slack API links like
+        #   `<https://google.com|Google>`. By default, markdown is not enabled
+        #   anywhere.
+        # @option attachments [String] :pretext The text to show before the
+        #   attachment (will not be inside the color bar).
+        # @option attachments [String] :author_name The author's full name to
+        #   show at the top of the message, inside the color border.
+        # @option attachments [String] :author_link A valid URL that will
+        #   hyperlink the `author_name` text.
+        # @option attachments [String] :author_icon A valid URL that displays a
+        #   small 16x16px image to the left of the `author_name` text.
+        # @option attachments [String] :title A title to display in larger,
+        #   bold text at the top of the attachment, inside the color border).
+        # @option attachments [String] :title_link A URL for the `title` to
+        #   link to.
+        # @option attachments [String] :text The text of the attachment.
+        # @option attachments [Array<Hash>] :fields A list of fields to display,
+        #  each of which is a Hash with `:title` and `:value` fields to display
+        #  the name and value of the field, and an optional `:short` to indicate
+        #  that the `value` is short enough to display side-by-side with other
+        #  values. e.g. `[ { "title": "ID", value: "100", short: true }]`
+        # @option attachments [String] :image_url A valid URL to a GIF, JPEG,
+        #  PNG or BMP image that will be shown inside the attachment. Images
+        #  larger than 400x500px will be resized down, maintaining aspect ratio.
+        # @option attachments [String] :thumb_url A valid URL to a GIF, JPEG,
+        #  PNG or BMP image that will be shown to the right of the attachment
+        #  as a thumbnail. Images larger than 75x75px will be resized down,
+        #  maintaining aspect ratio. Images must be smaller than 500KB.
+        # @option attachments [String] :footer Brief context for the attachment
+        #  that will be displayed below it, inside the color bar. Maximum
+        #  300 characters.
+        # @option attachments [String] :footer_icon A valid URL to a small icon
+        #  to display next to the `footer`. Icons will be resized to 16x16px.
+        # @option attachments [String] :ts Timestamp for the events described in the
+        #  attachment, in UTC epoch time (e.g. `Time.now.utc.to_i`). Displayed
+        #  to the right of the `footer`, inside the color bar.
+        # @param parse ["none", "full"] Governs what formatting you can put in your
+        #   messages and attachments.
+        #
+        #   Setting `parse` to `"none"` lets you pass links and directives with
+        #   angle brackets `<https://google.com|Google>`, and automatically
+        #   finds and linkifies URLs in the message (like `https://google.com`).
+        #   See the [Slack formatting docs](https://api.slack.com/docs/formatting)
+        #   for more information on the subject. It also turns off
+        #   `unfurl_media`.
+        #
+        #   Setting `parse` to `"full"` disables angle bracket links and
+        #   directives, instead showing the angle brackets to the user (so
+        #   `<https://google.com|Google>` prints out as `<https://google.com|Google>`),
+        #   and turns on `link_names`. (NOTE: contrary to Slack documentation,
+        #   setting `parse` to `"full"` does not appear to turn on `unfurl_links`.)
+        #
+        #   By default, angle brackets are ignored like in `full` but
+        #   `link_names` remains off.
+        # @param mrkdwn [0] When set to `0`, disables Slack-flavored markdown
+        #   such as bold and italics in the message.
+        # @param link_names [1] When set to `1`, tells Slack to find and linkify
+        #   channel and usernames such as @user and #channel in messages and
+        #   attachments. Slack has this off by default, but if `parse` is
+        #   `"full"`, it's turned on.
+        # @param unfurl_links [Boolean] When set to `true`, Slack will find URLs
+        #   in your message that point to non-media stuff (like Google or
+        #   Github) and generate an attachment automatically for them. Defaults
+        #   to `false`.
+        # @param unfurl_media [Boolean] When set to `true`, Slack will find URLs
+        #   in messages and attachments that point to images, video, sound, etc.
+        #   and [generate attachments for
+        #   them](https://api.slack.com/docs/unfurling) automatically. This
+        #   defaults to `false`, but is `parse` is `"full"`, it's turned on.
+        # @param as_user [Boolean, nil]  Determines whether the bot posts as
+        #   an authenticated user. If set to `true`, `username`, `icon_emoji`
+        #   and `icon_url` are ignored and the actual bot user's username,
+        #   icon_emoji and icon_url are used. Posting as a bot can be useful if
+        #   you want to change the bot's icon on a per-message basis. If you
+        #   pass `nil`, `as_user` will not be sent to Slack and Slack will guess
+        #   a value for you. Defaults to `true`.
+        # @param username [String] The display name for the user (not the
+        #   `@nickname`, the full name). Defaults to the bot's Slack-configured
+        #   username.
+        # @param icon_emoji [String] An emoji for the Bot's post (e.g. `:lol:`).
+        #   Defaults to the bot's Slack-configured icon emoji.
+        # @param icon_url [String] The URL to an image for the Bot's icon.
+        #   Defaults to the bot's Slack-configured icon.
+        #
+        # @return [Hash] The sent message response, as seen in
+        #   https://api.slack.com/methods/chat.postMessage#response. In
         #   particular, `response["ts"]` can be used as the `ts` argument to
         #   update_message and delete_message.
-        def send_messages(target, strings=nil, **message_arguments)
-          message_arguments[:text] = Array(strings).join("\n") unless strings.nil?
-          api.post_message(channel: channel_for(target), **message_arguments)
-        end
-        alias_method :send_message, :send_messages
+        #
+        # @example Sending a message
+        #
+        # ```ruby
+        # robot.chat_service.post_message(my_room,
+        #   text: "hi",
+        #   attachments: [
+        #     { text: "attached", fallback: "fallback" }
+        #   ])
+        # ==>
+        #   {"ok"=>true,
+        #    "channel"=>"C134JG51Q",
+        #    "ts"=>"1465845792.000008",
+        #    "message"=>
+        #     {"text"=>"hi",
+        #      "username"=>"bot",
+        #      "bot_id"=>"B134DKK08",
+        #      "attachments"=>
+        #       [{"text"=>"attached", "id"=>1, "fallback"=>"fallback"}],        #      "type"=>"message",
+        #      "subtype"=>"bot_message",
+        #      "ts"=>"1465845792.000008"}}
+        # ```
+        #
+        def post_message(target,
+            text: nil,
+            attachments: nil,
+            parse: nil,
+            link_names: nil,
+            unfurl_links: nil,
+            unfurl_media: nil,
+            mrkdwn: nil,
+            as_user: nil,
+            username: nil,
+            icon_emoji: nil,
+            icon_url: nil)
 
-        # @param target [Lita::Room, Lita::User] A room or user object
-        #   indicating where the message should be sent.
+          api.call_api("chat.postMessage",
+            channel: api.channel_for(target),
+            text: text,
+            attachments: attachments,
+            parse: parse,
+            link_names: link_names,
+            unfurl_links: unfurl_links,
+            unfurl_media: unfurl_media,
+            mrkdwn: mrkdwn,
+            as_user: as_user,
+            username: username,
+            icon_emoji: icon_emoji,
+            icon_url: icon_url)
+        end
+
+        #
+        # Send a `/me` message to a Slack channel.
+        #
+        # @param target [Lita::Source, Lita::Room, Lita::User, String] A Lita
+        #   source, room or user object, or a Slack channel ID, indicating where
+        #   the message should be sent.
         # @param text [String] The message to /me send.
         # @return [Hash] The Slack sent message response, as seen in
         #   https://api.slack.com/methods/chat.meMessage#response . In
         #   particular, `response["ts"]` can be used as the `ts` argument to
         #   update_message and delete_message.
         def me_message(target, text)
-          api.me_message(channel: channel_for(target), text: text)
+          api.call_api("chat.meMessage",
+            channel: api.channel_for(target),
+            text: text)
         end
 
-        # @param target [Lita::Room, Lita::User] A room or user object
-        #   indicating where the message should be sent.
-        # @param ts [Integer] The timestamp of the message (uniquely identifying it).
-        # @param strings [String, Array<String>] A string or strings to send as
-        #   text.
-        # @param arguments [Hash] Message arguments to send to Slack,
-        #   governing formatting. Arguments correspond to Slack `chat.update`
-        #   arguments and will override `config.default_message_arguments`. See
-        #   README for a list of known arguments.
-        # @return [Hash] The Slack sent message response, as seen in
-        #   https://api.slack.com/methods/chat.update#response .
-        def update_message(target, ts, strings=nil, **arguments)
-          arguments[:text] = Array(strings).join("\n") unless strings.nil?
-          api.chat_update(channel: channel_for(target), ts: ts, **arguments)
+        #
+        # Update an existing Slack message.
+        #
+        # Links on updated messages are not unfurled. Attachments are replaced
+        # only if `attachments` are passed (otherwise they are left alone).
+        #
+        # You can get the `ts` of a message at creation time by taking the result
+        # of `me_message` or `post_message`:
+        #
+        # @param target [Lita::Source, Lita::Room, Lita::User, String] A Lita
+        #   source, room or user object, or a Slack channel ID, indicating where
+        #   the message should be sent.
+        # @param ts [String] The timestamp of the message (uniquely identifying
+        #   it within the channel).
+        # @param text [String] The text of the message. Either text or attachments
+        #   is required.
+        # @param attachments [Array<Hash, Attachment>] A list of attachments to
+        #   the message. If `attachments` is not passed, the text is left alone;
+        #   otherwise, it is entirely replaced. Each attachment must be either
+        #   an attachment object or a Hash of the form specified in
+        #   https://api.slack.com/docs/attachments#attachment_structure.
+        #
+        #   `pretext`, `title`, `text`, field `value` and `footer` are affected
+        #   by `parse` and `link_names`.
+        #
+        #   Markdown is not enabled in any field by default. See the `mrkdwn_in`
+        #   option to control markdown formatting in pretext, text
+        #   and fields. Slack links like `<https://google.com|Google>` are
+        #   *always* enabled in pretext, title, text, field values and footer,
+        #   and never enabled in author_name and field titles.
+        # @option attachments [String] :fallback Required plain-text summary of
+        #   the attachment.
+        # @option attachments [:good, :warning, :danger, String] :color The
+        #   color of the left border of the attachment. good=green,
+        #   warning=yellow, danger=red. Pass `"#<hex>"` for an arbitrary color
+        #   (e.g. `"#439FE0"`).
+        # @option mrkdwn_in [Array<String>] :mrkdwn_in The list of elements with
+        #   markdown in them. Passing `["pretext"]` will enable markdown in
+        #   `pretext` but not in `text`. Possible values include `"pretext"`,
+        #   `"text"` and `"fields"` (which will affect only field values, not
+        #   field titles). This does not affect Slack API links like
+        #   `<https://google.com|Google>`. By default, markdown is not enabled
+        #   anywhere.
+        # @option attachments [String] :pretext The text to show before the
+        #   attachment (will not be inside the color bar).
+        # @option attachments [String] :author_name The author's full name to
+        #   show at the top of the message, inside the color border.
+        # @option attachments [String] :author_link A valid URL that will
+        #   hyperlink the `author_name` text.
+        # @option attachments [String] :author_icon A valid URL that displays a
+        #   small 16x16px image to the left of the `author_name` text.
+        # @option attachments [String] :title A title to display in larger,
+        #   bold text at the top of the attachment, inside the color border).
+        # @option attachments [String] :title_link A URL for the `title` to
+        #   link to.
+        # @option attachments [String] :text The text of the attachment.
+        # @option attachments [Array<Hash>] :fields A list of fields to display,
+        #  each of which is a Hash with `:title` and `:value` fields to display
+        #  the name and value of the field, and an optional `:short` to indicate
+        #  that the `value` is short enough to display side-by-side with other
+        #  values. e.g. `[ { "title": "ID", value: "100", short: true }]`
+        # @option attachments [String] :image_url A valid URL to a GIF, JPEG,
+        #  PNG or BMP image that will be shown inside the attachment. Images
+        #  larger than 400x500px will be resized down, maintaining aspect ratio.
+        # @option attachments [String] :thumb_url A valid URL to a GIF, JPEG,
+        #  PNG or BMP image that will be shown to the right of the attachment
+        #  as a thumbnail. Images larger than 75x75px will be resized down,
+        #  maintaining aspect ratio. Images must be smaller than 500KB.
+        # @option attachments [String] :footer Brief context for the attachment
+        #  that will be displayed below it, inside the color bar. Maximum
+        #  300 characters.
+        # @option attachments [String] :footer_icon A valid URL to a small icon
+        #  to display next to the `footer`. Icons will be resized to 16x16px.
+        # @option attachments [String] :ts Timestamp for the events described in the
+        #  attachment, in UTC epoch time (e.g. `Time.now.utc.to_i`). Displayed
+        #  to the right of the `footer`, inside the color bar.
+        # @param parse ["none", "full"] Governs what formatting you can put in your
+        #   messages and attachments.
+        #
+        #   Setting `parse` to `"none"` lets you pass links and directives with
+        #   angle brackets `<https://google.com|Google>`, and automatically
+        #   finds and linkifies URLs in the message (like `https://google.com`).
+        #   See the [Slack formatting docs](https://api.slack.com/docs/formatting)
+        #   for more information on the subject.
+        #
+        #   Setting `parse` to `"full"` disables angle bracket links and
+        #   directives, instead showing the angle brackets to the user (so
+        #   `<https://google.com|Google>` prints out as `<https://google.com|Google>`),
+        #   and turns on `link_names`.
+        #
+        #   By default, angle brackets are ignored like in `full` but
+        #   `link_names` remains off.
+        # @param link_names [1] When set to `1`, tells Slack to find and linkify
+        #   channel and usernames such as @user and #channel in messages and
+        #   attachments. Slack has this off by default, but if `parse` is
+        #   `"full"`, it's turned on.
+        #
+        # @return [Hash] The sent message response, as seen in
+        #   https://api.slack.com/methods/chat.update#response.
+        #
+        # @example Creating and then updating a message
+        #
+        # ```
+        # message = robot.chat_service.post_message(my_room, text: "Starting operation ...")
+        # robot.chat_service.update_message(message["channel"], message["ts"], text: "Updated!")
+        # ==> {"ok"=>true,
+        #  "channel"=>"C134JG51Q",
+        #  "ts"=>"1465849942.000079",
+        #  "text"=>"Updated!",
+        #  "message"=>
+        #   {"text"=>"Updated!",
+        #    "username"=>"bot",
+        #    "bot_id"=>"B134DKK08",
+        #    "mrkdwn"=>true,
+        #    "type"=>"message",
+        #    "subtype"=>"bot_message"}}
+        # ```
+        #
+        def update_message(target, ts,
+          text: nil,
+          attachments: nil,
+          parse: nil,
+          link_names: nil
+          )
+
+          api.call_api("chat.update",
+            channel: api.channel_for(target),
+            ts: ts,
+            text: text,
+            attachments: attachments,
+            parse: parse,
+            link_names: link_names)
         end
 
+        #
+        # Delete an existing Slack message.
+        #
         # @param target [Lita::Room, Lita::User] A room or user object
         #   indicating where the message should be sent.
-        # @param ts [Integer] The timestamp of the message (uniquely identifying it).
-        # @param arguments [Hash] Extra arguments to send to Slack.
-        #   `config.default_message_arguments[:as_user]` will be used if
-        #   `as_user` is not specified.
+        # @param ts [String] The timestamp of the message (uniquely identifying
+        #   it within the channel).
+        #
         # @return [Hash] The Slack deleted message response, as seen in
         #   https://api.slack.com/methods/chat.delete#response .
-        def delete_message(target, ts, **arguments)
-          api.chat_delete(channel: channel_for(target), ts: ts, **arguments)
+        #
+        def delete_message(target, ts)
+          api.call_api("chat.delete", channel: api.channel_for(target), ts: ts)
         end
 
+        #
+        # Send attachments to Slack.
+        #
         # @param target [Lita::Source, Lita::Room, Lita::User] A room or user
         #        object indicating where the attachment should be sent.
         # @param attachments [Attachment, Hash, Array<Attachment>, Hash<String>] An {Attachment} or array of
         #   {Attachment}s to send.
+        #
         # @return [void]
-        def send_attachments(target, attachments, **message_arguments)
-          message_arguments[:attachments] = Array(attachments)
-          api.post_message(channel: channel_for(target), **message_arguments)
+        #
+        def send_attachments(target, attachments)
+          post_message(target, attachments: Array(attachments))
         end
         alias_method :send_attachment, :send_attachments
-
-        private
-
-        def channel_for(target)
-          case target
-          when Lita::Source
-            if target.private_message?
-              rtm_connection.im_for(target.user.id)
-            else
-              target.room
-            end
-
-          when Lita::Room, Lita::User
-            target.id
-
-          else
-            target
-          end
-        end
       end
     end
   end

--- a/lib/lita/adapters/slack/chat_service.rb
+++ b/lib/lita/adapters/slack/chat_service.rb
@@ -8,21 +8,58 @@ module Lita
       # @since 1.6.0
       class ChatService
         attr_accessor :api
+        attr_reader :rtm_connection
 
         # @param config [Lita::Configuration] The adapter's configuration data.
-        def initialize(config)
+        def initialize(config, rtm_connection=nil)
           self.api = API.new(config)
+          @rtm_connection = rtm_connection
         end
 
         # @param target [Lita::Room, Lita::User] A room or user object indicating where the
         #   attachment should be sent.
-        # @param attachments [Attachment, Array<Attachment>] An {Attachment} or array of
+        # @param strings [String, Array<String>] A string or strings to send as
+        #   text.
+        # @param message_arguments [Hash] Message arguments to send to Slack,
+        #   governing formatting. Arguments correspond to Slack `chat.postMessage`
+        #   arguments and will override `config.default_message_arguments`. See
+        #   README for a list of known arguments.
+        # @return [void]
+        def send_messages(target, strings=nil, **message_arguments)
+          message_arguments[:text] = Array(strings).join("\n") unless strings.nil?
+          api.post_message(channel: channel_for(target), **message_arguments)
+        end
+        alias_method :send_message, :send_messages
+
+        # @param target [Lita::Source, Lita::Room, Lita::User] A room or user
+        #        object indicating where the attachment should be sent.
+        # @param attachments [Attachment, Hash, Array<Attachment>, Hash<String>] An {Attachment} or array of
         #   {Attachment}s to send.
         # @return [void]
-        def send_attachments(target, attachments)
-          api.send_attachments(target, Array(attachments))
+        def send_attachments(target, attachments, **message_arguments)
+          message_arguments[:attachments] = Array(attachments)
+          api.post_message(channel: channel_for(target), **message_arguments)
         end
         alias_method :send_attachment, :send_attachments
+
+        private
+
+        def channel_for(target)
+          case target
+          when Lita::Source
+            if target.private_message?
+              rtm_connection.im_for(target.user.id)
+            else
+              target.room
+            end
+
+          when Lita::Room, Lita::User
+            target.id
+
+          else
+            target
+          end
+        end
       end
     end
   end

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -336,245 +336,221 @@ describe Lita::Adapters::Slack::API do
     end
   end
 
-  describe "#send_attachments" do
-    let(:attachment) do
-      Lita::Adapters::Slack::Attachment.new(attachment_text)
-    end
-    let(:attachment_text) { "attachment text" }
-    let(:attachment_hash) do
-      {
-        fallback: fallback_text,
-        text: attachment_text,
-      }
-    end
-    let(:fallback_text) { attachment_text }
-    let(:http_response) { MultiJson.dump({ ok: true }) }
-    let(:room) { Lita::Room.new("C1234567890") }
-    let(:stubs) do
-      Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post(
-          "https://slack.com/api/chat.postMessage",
-          token: token,
-          as_user: true,
-          channel: room.id,
-          attachments: MultiJson.dump([attachment_hash]),
-        ) do
-          [http_status, {}, http_response]
-        end
-      end
-    end
-
-    context "with a simple text attachment" do
-      it "sends the attachment" do
-        response = subject.send_attachments(room, [attachment])
-
-        expect(response['ok']).to be(true)
-      end
-    end
-
-    context "with a different fallback message" do
-      let(:attachment) do
-        Lita::Adapters::Slack::Attachment.new(attachment_text, fallback: fallback_text)
-      end
-      let(:fallback_text) { "fallback text" }
-
-      it "sends the attachment" do
-        response = subject.send_attachments(room, [attachment])
-
-        expect(response['ok']).to be(true)
-      end
-    end
-
-    context "with all the valid options" do
-      let(:attachment) do
-        Lita::Adapters::Slack::Attachment.new(attachment_text, common_hash_data)
-      end
-      let(:attachment_hash) do
-        common_hash_data.merge(fallback: attachment_text, text: attachment_text)
-      end
-      let(:common_hash_data) do
-        {
-          author_icon: "http://example.com/author.jpg",
-          author_link: "http://example.com/author",
-          author_name: "author name",
-          color: "#36a64f",
-          fields: [{
-            title: "priority",
-            value: "high",
-            short: true,
-          }, {
-            title: "super long field title",
-            value: "super long field value",
-            short: false,
-          }],
-          image_url: "http://example.com/image.jpg",
-          pretext: "pretext",
-          thumb_url: "http://example.com/thumb.jpg",
-          title: "title",
-          title_link: "http://example.com/title",
-        }
-      end
-
-      it "sends the attachment" do
-        response = subject.send_attachments(room, [attachment])
-
-        expect(response['ok']).to be(true)
-      end
-    end
-
-    context "with a Slack error" do
-      let(:http_response) do
-        MultiJson.dump({
-          ok: false,
-          error: 'invalid_auth'
-        })
-      end
-
-      it "raises a RuntimeError" do
-        expect { subject.send_attachments(room, [attachment]) }.to raise_error(
-          "Slack API call to chat.postMessage returned an error: invalid_auth."
-        )
-      end
-    end
-
-    context "with an HTTP error" do
-      let(:http_status) { 422 }
-      let(:http_response) { '' }
-
-      it "raises a RuntimeError" do
-        expect { subject.send_attachments(room, [attachment]) }.to raise_error(
-          "Slack API call to chat.postMessage failed with status code 422: ''. Headers: {}"
-        )
-      end
-    end
-  end
-
-  describe "#send_messages" do
-    let(:messages) { ["attachment text"] }
-    let(:http_response) { MultiJson.dump({ ok: true }) }
-    let(:room) { "C1234567890" }
-    let(:stubs) do
-      Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post(
-          "https://slack.com/api/chat.postMessage",
-          token: token,
-          as_user: true,
-          channel: room,
-          text: messages.join("\n"),
-        ) do
-          [http_status, {}, http_response]
-        end
-      end
-    end
-
-    context "with a simple text attachment" do
-      it "sends the attachment" do
-        response = subject.send_messages(room, messages)
-
-        expect(response['ok']).to be(true)
-      end
-    end
-
-    context "with configuration" do
-      before do
-        allow(config).to receive(:link_names).and_return(true)
-      end
-
-      def stubs(postMessage_options = {})
+  describe "#post_message" do
+    context "messages" do
+      let(:message) { "message text" }
+      let(:http_response) { MultiJson.dump({ ok: true }) }
+      let(:channel) { "C1234567890" }
+      let(:stubs) do
         Faraday::Adapter::Test::Stubs.new do |stub|
           stub.post(
             "https://slack.com/api/chat.postMessage",
             token: token,
-            link_names: 1,
             as_user: true,
-            channel: room,
-            text: messages.join("\n"),
+            channel: channel,
+            text: message,
           ) do
             [http_status, {}, http_response]
           end
         end
       end
 
-      it "sends the message with configuration" do
-        response = subject.send_messages(room, messages)
+      context "with a simple message" do
+        it "sends the message" do
+          response = subject.post_message(channel: channel, text: message)
 
-        expect(response['ok']).to be(true)
+          expect(response['ok']).to be(true)
+        end
+      end
+
+      context "with configuration" do
+        before do
+          allow(config).to receive(:link_names).and_return(true)
+          allow(config).to receive(:default_message_arguments).and_return(unfurl_media: false)
+        end
+
+        context "and a simple message" do
+          def stubs(postmessage_arguments = {})
+            Faraday::Adapter::Test::Stubs.new do |stub|
+              stub.post(
+                "https://slack.com/api/chat.postMessage",
+                token: token,
+                link_names: 1,
+                unfurl_media: false,
+                channel: channel,
+                text: message
+              ) do
+                [http_status, {}, http_response]
+              end
+            end
+          end
+
+          it "sends the message with configuration" do
+            response = subject.post_message(channel: channel, text: message)
+
+            expect(response['ok']).to be(true)
+          end
+        end
+
+        context "and a message with arguments" do
+          def stubs(postmessage_arguments = {})
+            Faraday::Adapter::Test::Stubs.new do |stub|
+              stub.post(
+                "https://slack.com/api/chat.postMessage",
+                token: token,
+                link_names: 1,
+                unfurl_media: false,
+                parse: "none",
+                channel: channel,
+                text: message
+              ) do
+                [http_status, {}, http_response]
+              end
+            end
+          end
+
+          it "combines message arguments with configuration" do
+            response = subject.post_message(channel: channel, text: message, parse: "none")
+
+            expect(response['ok']).to be(true)
+          end
+        end
+
+        context "and a message with arguments that override configuration" do
+          def stubs(postmessage_arguments = {})
+            Faraday::Adapter::Test::Stubs.new do |stub|
+              stub.post(
+                "https://slack.com/api/chat.postMessage",
+                token: token,
+                link_names: 1,
+                unfurl_media: true,
+                channel: channel,
+                text: message
+              ) do
+                [http_status, {}, http_response]
+              end
+            end
+          end
+
+          it "message arguments override configuration" do
+            response = subject.post_message(channel: channel, text: message, unfurl_media: true)
+
+            expect(response['ok']).to be(true)
+          end
+        end
+      end
+
+      context "with a Slack error" do
+        let(:http_response) do
+          MultiJson.dump({
+            ok: false,
+            error: 'invalid_auth'
+          })
+        end
+
+        it "raises a RuntimeError" do
+          expect { subject.post_message(channel: channel, text: message) }.to raise_error(
+            "Slack API call to chat.postMessage returned an error: invalid_auth."
+          )
+        end
+      end
+
+      context "with an HTTP error" do
+        let(:http_status) { 422 }
+        let(:http_response) { '' }
+
+        it "raises a RuntimeError" do
+          expect { subject.post_message(channel: channel, text: message) }.to raise_error(
+            "Slack API call to chat.postMessage failed with status code 422: ''. Headers: {}"
+          )
+        end
       end
     end
 
-    context "with a different fallback message" do
+    context "attachments" do
       let(:attachment) do
-        Lita::Adapters::Slack::Attachment.new(attachment_text, fallback: fallback_text)
+        Lita::Adapters::Slack::Attachment.new(attachment_text)
       end
-      let(:fallback_text) { "fallback text" }
-
-      it "sends the attachment" do
-        response = subject.send_messages(room, messages)
-
-        expect(response['ok']).to be(true)
-      end
-    end
-
-    context "with all the valid options" do
-      let(:attachment) do
-        Lita::Adapters::Slack::Attachment.new(attachment_text, common_hash_data)
-      end
+      let(:attachment_text) { "attachment text" }
       let(:attachment_hash) do
-        common_hash_data.merge(fallback: attachment_text, text: attachment_text)
-      end
-      let(:common_hash_data) do
         {
-          author_icon: "http://example.com/author.jpg",
-          author_link: "http://example.com/author",
-          author_name: "author name",
-          color: "#36a64f",
-          fields: [{
-            title: "priority",
-            value: "high",
-            short: true,
-          }, {
-            title: "super long field title",
-            value: "super long field value",
-            short: false,
-          }],
-          image_url: "http://example.com/image.jpg",
-          pretext: "pretext",
-          thumb_url: "http://example.com/thumb.jpg",
-          title: "title",
-          title_link: "http://example.com/title",
+          fallback: fallback_text,
+          text: attachment_text,
         }
       end
-
-      it "sends the attachment" do
-        response = subject.send_messages(room, messages)
-
-        expect(response['ok']).to be(true)
+      let(:fallback_text) { attachment_text }
+      let(:http_response) { MultiJson.dump({ ok: true }) }
+      let(:channel) { "C1234567890" }
+      let(:stubs) do
+        Faraday::Adapter::Test::Stubs.new do |stub|
+          stub.post(
+            "https://slack.com/api/chat.postMessage",
+            token: token,
+            as_user: true,
+            channel: channel,
+            attachments: MultiJson.dump([attachment_hash]),
+          ) do
+            [http_status, {}, http_response]
+          end
+        end
       end
-    end
 
-    context "with a Slack error" do
-      let(:http_response) do
-        MultiJson.dump({
-          ok: false,
-          error: 'invalid_auth'
-        })
+      context "with a simple text attachment" do
+        it "sends the attachment" do
+          response = subject.post_message(channel: channel, attachments: [attachment])
+
+          expect(response['ok']).to be(true)
+        end
       end
 
-      it "raises a RuntimeError" do
-        expect { subject.send_messages(room, messages) }.to raise_error(
-          "Slack API call to chat.postMessage returned an error: invalid_auth."
-        )
+      context "with a different fallback message" do
+        let(:attachment) do
+          Lita::Adapters::Slack::Attachment.new(attachment_text, fallback: fallback_text)
+        end
+        let(:fallback_text) { "fallback text" }
+
+        it "sends the attachment" do
+          response = subject.post_message(channel: channel, attachments: [attachment])
+
+          expect(response['ok']).to be(true)
+        end
       end
-    end
 
-    context "with an HTTP error" do
-      let(:http_status) { 422 }
-      let(:http_response) { '' }
+      context "with all the valid options" do
+        let(:attachment) do
+          Lita::Adapters::Slack::Attachment.new(attachment_text, common_hash_data)
+        end
+        let(:attachment_hash) do
+          common_hash_data.merge(fallback: attachment_text, text: attachment_text)
+        end
+        let(:common_hash_data) do
+          {
+            author_icon: "http://example.com/author.jpg",
+            author_link: "http://example.com/author",
+            author_name: "author name",
+            color: "#36a64f",
+            fields: [{
+              title: "priority",
+              value: "high",
+              short: true,
+            }, {
+              title: "super long field title",
+              value: "super long field value",
+              short: false,
+            }],
+            image_url: "http://example.com/image.jpg",
+            pretext: "pretext",
+            thumb_url: "http://example.com/thumb.jpg",
+            title: "title",
+            title_link: "http://example.com/title",
+          }
+        end
 
-      it "raises a RuntimeError" do
-        expect { subject.send_messages(room, messages) }.to raise_error(
-          "Slack API call to chat.postMessage failed with status code 422: ''. Headers: {}"
-        )
+        it "sends the attachment" do
+          response = subject.post_message(channel: channel, attachments: [attachment])
+
+          expect(response['ok']).to be(true)
+        end
       end
     end
   end

--- a/spec/lita/adapters/slack/chat_service_spec.rb
+++ b/spec/lita/adapters/slack/chat_service_spec.rb
@@ -6,22 +6,63 @@ describe Lita::Adapters::Slack::ChatService, lita: true do
   let(:adapter) { Lita::Adapters::Slack.new(robot) }
   let(:robot) { Lita::Robot.new(registry) }
   let(:room) { Lita::Room.new("C2147483705") }
+  let(:room_source) { Lita::Source.new(room: "C2147483705") }
 
   before do
     registry.register_adapter(:slack, Lita::Adapters::Slack)
+  end
+
+  describe "#send_messages" do
+    let(:attachment) { Lita::Adapters::Slack::Attachment.new("attachment text") }
+
+    it "can send a simple message" do
+      expect(subject.api).to receive(:post_message).with(channel: room.id, text: "hi there")
+
+      subject.send_messages(room_source, "hi there")
+    end
+
+    it "can send multiple messages" do
+      expect(subject.api).to receive(:post_message).with(channel: room.id, text: "a\nb")
+
+      subject.send_messages(room_source, [ "a", "b" ])
+    end
+
+    it "can send attachments without text" do
+      expect(subject.api).to receive(:post_message).with(channel: room.id, attachments: [ attachment ])
+
+      subject.send_messages(room_source, attachments: [ attachment ])
+    end
+
+    it "can send attachments, text and message arguments" do
+      expect(subject.api).to receive(:post_message).with(channel: room.id, text: "a\nb", attachments: [ attachment ], parse: "none")
+
+      subject.send_messages(room_source, [ "a", "b" ], attachments: [ attachment ], parse: "none")
+    end
+
+    it "is aliased as send_message" do
+      expect(subject.api).to receive(:post_message).with(channel: room.id, text: "hi there")
+
+      subject.send_message(room_source, "hi there")
+    end
   end
 
   describe "#send_attachments" do
     let(:attachment) { Lita::Adapters::Slack::Attachment.new("attachment text") }
 
     it "can send a simple text attachment" do
-      expect(subject.api).to receive(:send_attachments).with(room, [attachment])
+      expect(subject.api).to receive(:post_message).with(channel: room.id, attachments: [attachment])
 
       subject.send_attachments(room, attachment)
     end
 
+    it "can send attachments and message arguments" do
+      expect(subject.api).to receive(:post_message).with(channel: room.id, attachments: [attachment], parse: "none")
+
+      subject.send_attachments(room, attachment, parse: "none")
+    end
+
     it "is aliased as send_attachment" do
-      expect(subject.api).to receive(:send_attachments).with(room, [attachment])
+      expect(subject.api).to receive(:post_message).with(channel: room.id, attachments: [attachment])
 
       subject.send_attachment(room, attachment)
     end

--- a/spec/lita/adapters/slack/chat_service_spec.rb
+++ b/spec/lita/adapters/slack/chat_service_spec.rb
@@ -5,8 +5,11 @@ describe Lita::Adapters::Slack::ChatService, lita: true do
 
   let(:adapter) { Lita::Adapters::Slack.new(robot) }
   let(:robot) { Lita::Robot.new(registry) }
-  let(:room) { Lita::Room.new("C2147483705") }
-  let(:room_source) { Lita::Source.new(room: "C2147483705") }
+  let(:channel) { "C2147483705" }
+  let(:room) { Lita::Room.new(channel) }
+  let(:username) { "TESTUSER"}
+  let(:user) { Lita::User.new(username)}
+  let(:room_source) { Lita::Source.new(room: channel) }
 
   before do
     registry.register_adapter(:slack, Lita::Adapters::Slack)
@@ -15,34 +18,130 @@ describe Lita::Adapters::Slack::ChatService, lita: true do
   describe "#send_messages" do
     let(:attachment) { Lita::Adapters::Slack::Attachment.new("attachment text") }
 
-    it "can send a simple message" do
-      expect(subject.api).to receive(:post_message).with(channel: room.id, text: "hi there")
-
+    it "can send a simple message to a room source" do
+      expect(subject.api).to receive(:post_message).with(channel: channel, text: "hi there")
       subject.send_messages(room_source, "hi there")
     end
 
+    it "can send a simple message to a room" do
+      expect(subject.api).to receive(:post_message).with(channel: channel, text: "hi there")
+      subject.send_messages(room, "hi there")
+    end
+
+    it "can send a simple message to a user" do
+      expect(subject.api).to receive(:post_message).with(channel: username, text: "hi there")
+      subject.send_messages(user, "hi there")
+    end
+
+    it "can send a simple message to a channel" do
+      expect(subject.api).to receive(:post_message).with(channel: channel, text: "hi there")
+      subject.send_messages(channel, "hi there")
+    end
+
+    it "returns the JSON from post_message" do
+      expect(subject.api).to receive(:post_message).with(channel: channel, text: "hi there").and_return("ok" => true)
+      expect(subject.send_messages(room_source, "hi there")).to eq("ok" => true)
+    end
+
     it "can send multiple messages" do
-      expect(subject.api).to receive(:post_message).with(channel: room.id, text: "a\nb")
+      expect(subject.api).to receive(:post_message).with(channel: channel, text: "a\nb")
 
       subject.send_messages(room_source, [ "a", "b" ])
     end
 
     it "can send attachments without text" do
-      expect(subject.api).to receive(:post_message).with(channel: room.id, attachments: [ attachment ])
+      expect(subject.api).to receive(:post_message).with(channel: channel, attachments: [ attachment ])
 
       subject.send_messages(room_source, attachments: [ attachment ])
     end
 
     it "can send attachments, text and message arguments" do
-      expect(subject.api).to receive(:post_message).with(channel: room.id, text: "a\nb", attachments: [ attachment ], parse: "none")
+      expect(subject.api).to receive(:post_message).with(channel: channel, text: "a\nb", attachments: [ attachment ], parse: "none")
 
       subject.send_messages(room_source, [ "a", "b" ], attachments: [ attachment ], parse: "none")
     end
 
     it "is aliased as send_message" do
-      expect(subject.api).to receive(:post_message).with(channel: room.id, text: "hi there")
+      expect(subject.api).to receive(:post_message).with(channel: channel, text: "hi there")
 
       subject.send_message(room_source, "hi there")
+    end
+  end
+
+  describe "#update_message" do
+    let(:attachment) { Lita::Adapters::Slack::Attachment.new("attachment text") }
+    let(:ts) { "1234.5678" }
+
+    it "can send a simple message to a room source" do
+      expect(subject.api).to receive(:chat_update).with(channel: channel, ts: ts, text: "hi there")
+      subject.update_message(room_source, ts, "hi there")
+    end
+
+    it "can send a simple message to a room" do
+      expect(subject.api).to receive(:chat_update).with(channel: channel, ts: ts, text: "hi there")
+      subject.update_message(room, ts, "hi there")
+    end
+
+    it "can send a simple message to a user" do
+      expect(subject.api).to receive(:chat_update).with(channel: username, ts: ts, text: "hi there")
+      subject.update_message(user, ts, "hi there")
+    end
+
+    it "can send a simple message to a channel" do
+      expect(subject.api).to receive(:chat_update).with(channel: channel, ts: ts, text: "hi there")
+      subject.update_message(channel, ts, "hi there")
+    end
+
+    it "returns the JSON from update_message" do
+      expect(subject.api).to receive(:chat_update).with(channel: channel, ts: ts, text: "hi there").and_return("ok" => true)
+      expect(subject.update_message(room_source, ts, "hi there")).to eq("ok" => true)
+    end
+
+    it "can update with multiple messages" do
+      expect(subject.api).to receive(:chat_update).with(channel: channel, ts: ts, text: "a\nb")
+
+      subject.update_message(room_source, ts, [ "a", "b" ])
+    end
+
+    it "can send attachments without text" do
+      expect(subject.api).to receive(:chat_update).with(channel: channel, ts: ts, attachments: [ attachment ])
+
+      subject.update_message(room_source, ts, attachments: [ attachment ])
+    end
+
+    it "can send attachments, text and message arguments" do
+      expect(subject.api).to receive(:chat_update).with(channel: channel, ts: ts, text: "a\nb", attachments: [ attachment ], parse: "none")
+
+      subject.update_message(room_source, ts, [ "a", "b" ], attachments: [ attachment ], parse: "none")
+    end
+  end
+
+  describe "#delete_message" do
+    let(:ts) { "1234.5678" }
+
+    it "can send a delete to a room source" do
+      expect(subject.api).to receive(:chat_delete).with(channel: channel, ts: ts)
+      subject.delete_message(room_source, ts)
+    end
+
+    it "can send a delete to a room" do
+      expect(subject.api).to receive(:chat_delete).with(channel: channel, ts: ts)
+      subject.delete_message(room, ts)
+    end
+
+    it "can send a delete to a user" do
+      expect(subject.api).to receive(:chat_delete).with(channel: username, ts: ts)
+      subject.delete_message(user, ts)
+    end
+
+    it "can send a delete to a channel" do
+      expect(subject.api).to receive(:chat_delete).with(channel: channel, ts: ts)
+      subject.delete_message(channel, ts)
+    end
+
+    it "returns the JSON from delete_message" do
+      expect(subject.api).to receive(:chat_delete).with(channel: channel, ts: ts).and_return("ok" => true)
+      expect(subject.delete_message(room_source, ts)).to eq("ok" => true)
     end
   end
 
@@ -50,19 +149,19 @@ describe Lita::Adapters::Slack::ChatService, lita: true do
     let(:attachment) { Lita::Adapters::Slack::Attachment.new("attachment text") }
 
     it "can send a simple text attachment" do
-      expect(subject.api).to receive(:post_message).with(channel: room.id, attachments: [attachment])
+      expect(subject.api).to receive(:post_message).with(channel: channel, attachments: [attachment])
 
       subject.send_attachments(room, attachment)
     end
 
     it "can send attachments and message arguments" do
-      expect(subject.api).to receive(:post_message).with(channel: room.id, attachments: [attachment], parse: "none")
+      expect(subject.api).to receive(:post_message).with(channel: channel, attachments: [attachment], parse: "none")
 
       subject.send_attachments(room, attachment, parse: "none")
     end
 
     it "is aliased as send_attachment" do
-      expect(subject.api).to receive(:post_message).with(channel: room.id, attachments: [attachment])
+      expect(subject.api).to receive(:post_message).with(channel: channel, attachments: [attachment])
 
       subject.send_attachment(room, attachment)
     end

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -1,21 +1,22 @@
 require "spec_helper"
+require "support/expect_api_call"
 
 describe Lita::Adapters::Slack, lita: true do
   subject { described_class.new(robot) }
 
   let(:robot) { Lita::Robot.new(registry) }
   let(:rtm_connection) { instance_double('Lita::Adapters::Slack::RTMConnection') }
-  let(:token) { 'abcd-1234567890-hWYd21AmMH2UHAkx29vb5c1Y' }
 
   before do
     registry.register_adapter(:slack, described_class)
-    registry.config.adapters.slack.token = token
 
     allow(
       described_class::RTMConnection
     ).to receive(:build).with(robot, subject.config).and_return(rtm_connection)
     allow(rtm_connection).to receive(:run)
   end
+
+  include ExpectApiCall
 
   it "registers with Lita" do
     expect(Lita.adapters[:slack]).to eql(described_class)
@@ -125,17 +126,32 @@ describe Lita::Adapters::Slack, lita: true do
     end
 
     describe "via the Web API" do
-      let(:api) { instance_double('Lita::Adapters::Slack::API') }
-
-      before do
-        allow(Lita::Adapters::Slack::API).to receive(:new).with(subject.config).and_return(api)
-      end
-
-      it "does not send via the RTM api" do
+      it "sends via the non-RTM API" do
         expect(rtm_connection).to_not receive(:send_messages)
-        expect(api).to receive(:post_message).with(channel: room_source.room, text: 'foo')
+        expect_api_call("chat.postMessage", channel: room_source.room, text: 'foo')
 
         subject.send_messages(room_source, ['foo'])
+      end
+
+      context "with parse, link_names, unfurl_media and unfurl_links configured" do
+        before do
+          registry.config.adapters.slack.parse = "none"
+          registry.config.adapters.slack.link_names = true
+          registry.config.adapters.slack.unfurl_media = true
+          registry.config.adapters.slack.unfurl_links = true
+        end
+
+        it "sends those arguments alongside messages" do
+          expect_api_call("chat.postMessage",
+            channel: room_source.room,
+            text: 'foo',
+            parse: "none",
+            link_names: 1,
+            unfurl_media: true,
+            unfurl_links: true
+          )
+          subject.send_messages(room_source, ['foo'])
+        end
       end
     end
   end

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -66,7 +66,7 @@ describe Lita::Adapters::Slack, lita: true do
       end
 
       it "returns UID(s)" do
-        expect(subject).to receive(:channel_roster).with(room_source.room_object.id, api)
+        expect(subject).to receive(:channel_roster).with(room_source.room_object.id)
 
         subject.roster(room_source.room_object)
       end
@@ -87,8 +87,8 @@ describe Lita::Adapters::Slack, lita: true do
       end
 
       it "returns UID(s)" do
-        expect(subject).to receive(:group_roster).with(room_source.room_object.id, api).and_return(%q{})
-        expect(subject).to receive(:mpim_roster).with(room_source.room_object.id, api).and_return(%q{G024BE91L})
+        expect(subject).to receive(:group_roster).with(room_source.room_object.id).and_return(%q{})
+        expect(subject).to receive(:mpim_roster).with(room_source.room_object.id).and_return(%q{G024BE91L})
 
         subject.roster(room_source.room_object)
       end
@@ -109,7 +109,7 @@ describe Lita::Adapters::Slack, lita: true do
       end
 
       it "returns UID" do
-        expect(subject).to receive(:im_roster).with(room_source.room_object.id, api)
+        expect(subject).to receive(:im_roster).with(room_source.room_object.id)
 
         subject.roster(room_source.room_object)
       end
@@ -133,7 +133,7 @@ describe Lita::Adapters::Slack, lita: true do
 
       it "does not send via the RTM api" do
         expect(rtm_connection).to_not receive(:send_messages)
-        expect(api).to receive(:send_messages).with(room_source.room, ['foo'])
+        expect(api).to receive(:post_message).with(channel: room_source.room, text: 'foo')
 
         subject.send_messages(room_source, ['foo'])
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -8,7 +8,6 @@ SimpleCov.start { add_filter "/spec/" }
 
 require "lita-slack"
 require "lita/rspec"
-
 require "pry"
 
 Lita.version_3_compatibility_mode = false

--- a/spec/support/expect_api_call.rb
+++ b/spec/support/expect_api_call.rb
@@ -1,0 +1,22 @@
+ module ExpectApiCall
+   # Return an API with stubs so we can easily stub network requests
+   def token
+     'abcd-1234567890-hWYd21AmMH2UHAkx29vb5c1Y'
+   end
+   def stubs
+     @stubs ||= Faraday::Adapter::Test::Stubs.new
+   end
+
+   def expect_api_call(method, response: { "ok" => true }, token: self.token, **arguments)
+     stubs.post("https://slack.com/api/#{method}", token: token, **arguments) do
+       [200, {}, MultiJson.dump(response)]
+     end
+   end
+
+   def self.included(other)
+     other.before do
+       registry.config.adapters.slack.token = token
+       allow_any_instance_of(Lita::Adapters::Slack::API).to receive(:stubs).and_return(stubs)
+     end
+   end
+end


### PR DESCRIPTION
This implements a `chat_service` API that lets you specify message arguments such as `parse: "none"` on a per-message basis (I don't want to mess up all the other plugins I have installed by changing message defaults globally). The README should document the change pretty well, I hope.

Here's a list of changes and the thoughts behind them:
1. Created `chat_service.send_message(target, strings=nil, **message_arguments)`. This is backcompat with `robot.send_message`, but can also be called with or without a message, and with attachments and other configuration (such as `parse: "none"` if so desired. Note: I named it arguments instead of options since that's how Slack describes it in their API docs.
2. Added `config.adapters.slack.default_message_arguments` as well. If this change is acceptable to you, we might want to remove `parse`, `unfurl_links`, etc. before releasing a version with those in it, since they would be redundant. If this isn't OK, I can pretty easily adapt the code to what it was before. My reasoning in making this change was, it supports all message arguments instead of just the 4, and it is flexible enough that if slack adds new options, we'll support them for free.
3. Replaced `api.send_messages` and `api.send_attachments` with `api.post_message` to match the actual Slack API call (since `api` seems like it's trying to stay more Slack-centric and less Lita-centric). `chat_service.send_messages` and `chat_service.send_attachments` call this API.

Let me know your thoughts! Thanks.
