### PR TITLE
Remove bot_message from supported_message_subtypes

### DIFF
--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -191,7 +191,7 @@ module Lita
 
         # Types of messages Lita should dispatch to handlers.
         def supported_message_subtypes
-          %w(bot_message me_message)
+          %w(me_message)
         end
 
         def supported_subtype?


### PR DESCRIPTION
See https://github.com/litaio/lita-slack/issues/94