### PR TITLE
Slack API does not specify that the second character be zero.

### DIFF
--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -96,13 +96,13 @@ module Lita
 
       def room_roster(room_id, api)
         case room_id
-        when /^C0/
+        when /^C/
           channel_roster room_id, api
-        when /^G0/
+        when /^G/
           # Groups & MPIMs have the same room ID pattern, check both if needed
           roster = group_roster room_id, api
           roster.empty? ? mpim_roster(room_id, api) : roster
-        when /^D0/
+        when /^D/
           im_roster room_id, api
         end
       end


### PR DESCRIPTION
This threw me for a loop as a few of our handlers started blowing up as new slack channels are starting with `C1...`  I cannot find any specification that list the 0 as a required number, only that 100% of the examples have a zero.

This removes the trailing zero to support new channels, ids and groups. 