### PR TITLE
Add :mention event when Slack user is mentioned.

### DIFF
--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -154,7 +154,8 @@ module Lita
           user = User.find_by_id(data["user"]) || User.create(data["user"])
 
           return if from_self?(user)
-
+          
+          mentions_user?
           dispatch_message(user)
         end
 
@@ -202,6 +203,25 @@ module Lita
           else
             true
           end
+        end
+
+        def mentions_user?
+          return if @data['text'].nil?
+          
+          keywords = User.redis.keys.map { |n| n.sub(/\Aname:|\Amention_name:|\Aid:/, '')}
+          user_aliases = Regexp.union(keywords)
+          matches = @data['text'].scan(user_aliases)
+          
+          if matches.any?
+            mentioned_users = matches.map { |str| User.fuzzy_find(str) }
+            mentioned_users.compact!
+            return if mentioned_users.empty?
+          else
+            return
+          end
+
+          payload = { users: mentioned_users }
+          robot.trigger(:mention, payload)
         end
       end
     end

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -110,6 +110,72 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
           subject.handle
         end
       end
+      
+      context "mentioning a Slack user" do
+          let(:user) { Lita::User.create('U023BECGF', name: "Bobby Tables", mention_name: 'bobby') }
+          let(:payload) { {users: [user]} }
+        
+        context "by mention name" do
+          let(:data) do
+            {
+              "type" => "message",
+              "channel" => "C2147483705",
+              "user" => "U01234567",
+              "text" => "#{user.mention_name} Hello"
+            }
+          end
+
+          before do
+            allow(Lita::Message).to receive(:new).with( robot, "#{user.mention_name} Hello", source).and_return(message)
+          end
+
+          it "triggers a :mention event" do
+            expect(robot).to receive(:trigger).with(:mention, payload)  
+
+            subject.handle
+          end
+        end
+
+        context "by user name" do
+          let(:data) do
+            {
+              "type" => "message",
+              "channel" => "C2147483705",
+              "user" => "U01234567",
+              "text" => "#{user.name} Hello"
+            }
+          end        
+
+          before do
+            allow(Lita::Message).to receive(:new).with( robot, "#{user.name} Hello", source).and_return(message)
+          end
+
+          it "triggers a :mention event" do
+            expect(robot).to receive(:trigger).with(:mention, payload)
+            subject.handle
+          end
+        end
+
+        context "with @-style Slack mention" do
+          let(:data) do
+            {
+              "type" => "message",
+              "channel" => "C2147483705",
+              "user" => "U01234567",
+              "text" => "<@#{user.id}> Hello"
+            }
+          end
+
+          before do
+            allow(Lita::Message).to receive(:new).with( robot, "@#{user.mention_name} Hello", source).and_return(message)
+          end
+
+          it "triggers a :mention event" do
+            expect(robot).to receive(:trigger).with(:mention, payload)
+            subject.handle
+          end
+        end
+      end
 
       context "when the message has attach" do
         let(:data) do


### PR DESCRIPTION
I went ahead and took a shot at #98. 

I'm not really satisfied with creating the`user_aliases` regex for every message but persisting in Redis seemed weird as well. Even if the feature isn't needed, I'd appreciate any feedback so I can release it as a separate plugin.

Thanks!