### PR TITLE
Fix rack to version 1.6.4

### DIFF
--- a/lita-slack.gemspec
+++ b/lita-slack.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "faye-websocket", ">= 0.8.0"
   spec.add_runtime_dependency "lita", ">= 4.7.0"
   spec.add_runtime_dependency "multi_json"
+  spec.add_runtime_dependency "rack", "1.6.4"
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
This should fix the problems with Travis failing due to `rack 2.0.1`'s requirement for Ruby 2.2.2. (See: #99 ) `rack 1.6.4` seems to be the latest stable release that doesn't care what version of Ruby you use so I pinned it to that.