### PR TITLE
Ignore messages from slackbot

### DIFF
--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -150,6 +150,7 @@ module Lita
 
         def handle_message
           return unless supported_subtype?
+          return if data["user"] == 'USLACKBOT'
 
           user = User.find_by_id(data["user"]) || User.create(data["user"])
 

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -473,6 +473,21 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
       end
     end
 
+    context "with a message from slackbot" do
+      let(:data) do
+        {
+          "type" => "message",
+          "user" => "USLACKBOT"
+        }
+      end
+
+      it "does not dispatch the message to Lita" do
+        expect(robot).not_to receive(:receive)
+
+        subject.handle
+      end
+    end
+
     context "with a message from the robot itself" do
       let(:data) do
         {


### PR DESCRIPTION
# Context

The other day, our lita bot responded to a message that came from [slackbot](https://get.slack.help/hc/en-us/articles/202026038-Slackbot-personal-assistant-and-helpful-bot-), the bot that comes built into slack. This seems bad.

https://github.com/litaio/lita-slack/pull/95 didn't help because messages only have subtype [`bot_message`](https://api.slack.com/events/message/bot_message) if they come from _integration_ bots, which slackbot is not. It seems that the only thing that distinguishes a slackbot message from other messages is the originating user. Slackbot's userid is `USLACKBOT`.

# This change

This change aborts handling a message that comes from the slackbot user.

It's not documented anywhere, but I have confirmed with the slack team that the way you check if a message is from slackbot is by checking that the userid is `USLACKBOT`.

# Feedback I'm looking for

- how does this change sound?
- how does the implementation look?
- anything else I can do to make this merge-worthy?

Thanks!