### PR TITLE
Add config.supported_message_subtypes for accepting bot messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ gem "lita-slack"
 * `proxy` (String) – Specify a HTTP proxy URL. (e.g. "http://squid.example.com:3128")
 * `unfurl_links` (Boolean) – Set to `true` to automatically add previews for all links in messages sent by Lita.
 * `unfurl_media` (Boolean) – Set to `false` to prevent automatic previews for media files in messages sent by Lita.
+* `supported_message_subtypes` (Array) – Specify sub-types of message to respond to. (e.g. `["bot_message"]` to accept messages from bots)
 
 **Note**: When using lita-slack, the adapter will overwrite the bot's name and mention name with the values set on the server, so `config.robot.name` and `config.robot.mention_name` will have no effect.
 

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -13,6 +13,7 @@ module Lita
       config :link_names, type: [true, false]
       config :unfurl_links, type: [true, false]
       config :unfurl_media, type: [true, false]
+      config :supported_message_subtypes, type: Array, default: []
 
       # Provides an object for Slack-specific features.
       def chat_service

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -3,11 +3,12 @@ module Lita
     class Slack < Adapter
       # @api private
       class MessageHandler
-        def initialize(robot, robot_id, data)
+        def initialize(robot, robot_id, data, config)
           @robot = robot
           @robot_id = robot_id
           @data = data
           @type = data["type"]
+          @config = config
         end
 
         def handle
@@ -33,6 +34,7 @@ module Lita
 
         private
 
+        attr_reader :config
         attr_reader :data
         attr_reader :robot
         attr_reader :robot_id
@@ -192,7 +194,7 @@ module Lita
 
         # Types of messages Lita should dispatch to handlers.
         def supported_message_subtypes
-          %w(me_message)
+          (config && config.supported_message_subtypes).to_a + %w(me_message)
         end
 
         def supported_subtype?

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -97,7 +97,7 @@ module Lita
         def receive_message(event)
           data = MultiJson.load(event.data)
 
-          EventLoop.defer { MessageHandler.new(robot, robot_id, data).handle }
+          EventLoop.defer { MessageHandler.new(robot, robot_id, data, config).handle }
         end
 
         def safe_payload_for(channel, string)


### PR DESCRIPTION
This adds a config to bring back functionality removed by https://github.com/litaio/lita-slack/issues/95.