### PR TITLE
Add "item_user" to payload of reaction events

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Lita will join your default channel after initial setup. To have it join additio
 * `:connected` - When the robot has connected to Slack. No payload.
 * `:disconnected` - When the robot has disconnected from Slack. No payload.
 * `:slack_channel_created` - When the robot creates/updates a channel's or group's info, as directed by Slack. The payload has a single object, a `Lita::Slack::Adapters::SlackChannel` object, under the `:slack_channel` key.
-* `:slack_reaction_added` - When a reaction has been added to a previous message. The payload includes `:user` (a `Lita::User` for the sender of the message in question), `:name` (the string name of the reaction added), `:item` (a hash of raw data from Slack about the message), and `:event_ts` (a string timestamp used to identify the message).
+* `:slack_reaction_added` - When a reaction has been added to a previous message. The payload includes `:user` (a `Lita::User` for the sender of the message in question), `:name` (the string name of the reaction added), `:item_user` (a `Lita::User` for the user that created the original item that has been reacted to), `:item` (a hash of raw data from Slack about the message), and `:event_ts` (a string timestamp used to identify the message).
 * `:slack_reaction_removed` - When a reaction has been removed from a previous message. The payload is the same as the `:slack_reaction_added` message.
 * `:slack_user_created` - When the robot creates/updates a user's info - name, mention name, etc., as directed by Slack. The payload has a single object, a `Lita::Slack::Adapters::SlackUser` object, under the `:slack_user` key.
 

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -168,8 +168,11 @@ module Lita
           # avoid processing reactions added/removed by self
           return if from_self?(user)
 
+          # find or create item_user
+          item_user = User.find_by_id(data["item_user"]) || User.create(data["item_user"])
+
           # build a payload following slack convention for reactions
-          payload = { user: user, name: data["reaction"], item: data["item"], event_ts: data["event_ts"] }
+          payload = { user: user, name: data["reaction"], item_user: item_user, item: data["item"], event_ts: data["event_ts"] }
 
           # trigger the appropriate slack reaction event
           robot.trigger("slack_#{type}".to_sym, payload)

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -596,16 +596,19 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
         {
           "type" => "reaction_added",
           "user" => "U023BECGF",
+          "item_user" => "U0G9QF9C6",
           "item"=>{"type"=>"message", "channel"=>"C2147483705", "ts"=>"1234567.000008"},
           "reaction"=>"+1",
           "event_ts"=>"1234.5678"
         }
       end
       let(:user) { instance_double('Lita::User', id: 'U023BECGF') }
-      let(:payload) { {user: user, name: data["reaction"], item: data["item"], event_ts: data["event_ts"]} }
+      let(:item_user) { instance_double('Lita::User', id: 'U0G9QF9C6') }
+      let(:payload) { {user: user, name: data["reaction"], item_user: item_user, item: data["item"], event_ts: data["event_ts"]} }
 
       before do
-        allow(Lita::User).to receive(:find_by_id).and_return(user)
+        allow(Lita::User).to receive(:find_by_id).with(user.id).and_return(user)
+        allow(Lita::User).to receive(:find_by_id).with(item_user.id).and_return(item_user)
         allow(robot).to receive(:trigger).with(:slack_reaction_added, payload)
       end
 
@@ -620,16 +623,19 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
         {
           "type" => "reaction_removed",
           "user" => "U023BECGF",
+          "item_user" => "U0G9QF9C6",
           "item"=>{"type"=>"message", "channel"=>"C2147483705", "ts"=>"1234567.000008"},
           "reaction"=>"+1",
           "event_ts"=>"1234.5678"
         }
       end
       let(:user) { instance_double('Lita::User', id: 'U023BECGF') }
-      let(:payload) { {user: user, name: data["reaction"], item: data["item"], event_ts: data["event_ts"]} }
+      let(:item_user) { instance_double('Lita::User', id: 'U0G9QF9C6') }
+      let(:payload) { {user: user, name: data["reaction"], item_user: item_user, item: data["item"], event_ts: data["event_ts"]} }
 
       before do
         allow(Lita::User).to receive(:find_by_id).and_return(user)
+        allow(Lita::User).to receive(:find_by_id).with(item_user.id).and_return(item_user)
         allow(robot).to receive(:trigger).with(:slack_reaction_removed, payload)
       end
 


### PR DESCRIPTION
Both `slack_reaction_added` and `slack_reaction_remove` events include the user that
created the original item that has been reacted to.

More information:

https://api.slack.com/events/reaction_added
https://api.slack.com/events/reaction_removed