### PR TITLE
Add back profile metadata, with a test

### DIFF
--- a/lib/lita/adapters/slack/user_creator.rb
+++ b/lib/lita/adapters/slack/user_creator.rb
@@ -7,8 +7,7 @@ module Lita
           def create_user(slack_user, robot, robot_id)
             User.create(
               slack_user.id,
-              name: real_name(slack_user),
-              mention_name: slack_user.name
+              metadata(slack_user)
             )
 
             update_robot(robot, slack_user) if slack_user.id == robot_id
@@ -28,6 +27,23 @@ module Lita
           def update_robot(robot, slack_user)
             robot.name = slack_user.real_name
             robot.mention_name = slack_user.name
+          end
+
+          def metadata(slack_user)
+            meta = (slack_user.metadata['profile'] || {}).select do |key, value|
+              # Suppress invalid profile attributes:
+              #
+              # "Data that has not been supplied may not be present at all,
+              # may be null or may contain the empty string ("")."
+              # https://api.slack.com/methods/users.list
+              #
+              # Also reject empty arrays: https://github.com/litaio/lita-slack/issues/57
+              not value.nil? || value == '' || value.is_a?(Array) && value.compact.empty?
+            end
+
+            meta[:name] = real_name(slack_user)
+            meta[:mention_name] = slack_user.name
+            meta
           end
         end
       end

--- a/spec/lita/adapters/slack/user_creator_spec.rb
+++ b/spec/lita/adapters/slack/user_creator_spec.rb
@@ -45,6 +45,49 @@ describe Lita::Adapters::Slack::UserCreator do
         described_class.create_users([bobby], robot, robot_id)
       end
     end
+
+    context "with supplemental profile data" do
+      let(:slack_data) do
+        {
+          "id" => "U023BECGF",
+          "name" => "bobby",
+          "real_name" => real_name,
+          "profile" => {
+              "first_name" => "Bobby",
+              "last_name" => "Tables",
+              "real_name" => real_name,
+              "email" => email,
+              # Tests that top-level attributes override profile ones
+              name: "Should be clobbered by top-level name",
+              # Various invalid attributes that should not be passed to Lita
+              "null-attribute" => nil,
+              "empty-string-attribute" => '',
+              "empty-array-attribute" => [],
+              "compactible-array-attribute" => [ nil ]
+          }
+        }
+      end
+
+      let (:correct_metadata) do
+        {
+          name: 'Bobby Tables',
+          mention_name: 'bobby',
+          "first_name" => "Bobby",
+          "last_name" => "Tables",
+          "real_name" => real_name,
+          "email" => email
+        }
+      end
+
+      it "submits profile data as part of the user record" do
+        expect(Lita::User).to receive(:create).with(
+          'U023BECGF',
+          correct_metadata
+        )
+
+        described_class.create_users([bobby], robot, robot_id)
+      end
+    end
   end
 
   describe ".create_user" do


### PR DESCRIPTION
This builds on https://github.com/litaio/lita-slack/pull/80
which has not received a response by the original committer.
