### PR TITLE
Pass all events to handlers vs noop

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Lita will join your default channel after initial setup. To have it join additio
 * `:slack_reaction_added` - When a reaction has been added to a previous message. The payload includes `:user` (a `Lita::User` for the sender of the message in question), `:name` (the string name of the reaction added), `:item_user` (a `Lita::User` for the user that created the original item that has been reacted to), `:item` (a hash of raw data from Slack about the message), and `:event_ts` (a string timestamp used to identify the message).
 * `:slack_reaction_removed` - When a reaction has been removed from a previous message. The payload is the same as the `:slack_reaction_added` message.
 * `:slack_user_created` - When the robot creates/updates a user's info - name, mention name, etc., as directed by Slack. The payload has a single object, a `Lita::Slack::Adapters::SlackUser` object, under the `:slack_user` key.
+* `:slack_<<all_other_slack_event_types>>` - All other event types, such as presence_change are called with the entire body of the event from slack.
 
 ## Chat service API
 

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -179,9 +179,11 @@ module Lita
         end
 
         def handle_unknown
-          unless data["reply_to"]
-            log.debug("#{type} event received from Slack and will be ignored.")
-          end
+          return if data["reply_to"]
+
+          log.info("slack_#{type} event received from Slack.")
+
+          robot.trigger("slack_#{type}".to_sym, data)
         end
 
         def handle_user_change

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -649,8 +649,8 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
       let(:data) { { "type" => "???" } }
 
       it "logs the type" do
-        expect(Lita.logger).to receive(:debug).with(
-          "??? event received from Slack and will be ignored."
+        expect(Lita.logger).to receive(:info).with(
+          "??? event received from Slack."
         )
 
         subject.handle


### PR DESCRIPTION
The intent of this pull request is to allow handlers to be able to observe other events such as `presence_change`.  This changes the default behavior of sending unhandled events to a NOOP instead to be a simple passthrough. The entire payload of the event is passed on to the event with no maniuplation.  

Possible further steps are to check for standard hash keys and convert them to `Lita::User` and `Lita::Room`.