### PR TITLE
Add profile field to slack user and lita user objects

### DIFF
--- a/lib/lita/adapters/slack/slack_user.rb
+++ b/lib/lita/adapters/slack/slack_user.rb
@@ -27,8 +27,8 @@ module Lita
         attr_reader :name
         # @return [String] The user's display name, e.g. Alice Bobhart
         attr_reader :real_name
-        # @return [String] The user's email address, e.g. alice@example.com
-        attr_reader :email
+        # @return [Hash] The user's profile object from slack
+        attr_reader :profile
         # @return [Hash] The raw user data received from Slack, including many more fields.
         attr_reader :metadata
 
@@ -36,7 +36,7 @@ module Lita
           @id = id
           @name = name
           @real_name = real_name.to_s
-          @email = metadata['email'].to_s
+          @profile = metadata['profile'] || Hash.new('')
           @metadata = metadata
         end
 

--- a/lib/lita/adapters/slack/user_creator.rb
+++ b/lib/lita/adapters/slack/user_creator.rb
@@ -8,7 +8,8 @@ module Lita
             User.create(
               slack_user.id,
               name: real_name(slack_user),
-              mention_name: slack_user.name
+              mention_name: slack_user.name,
+              email: slack_user.profile['email']
             )
 
             update_robot(robot, slack_user) if slack_user.id == robot_id

--- a/spec/lita/adapters/slack/slack_user_spec.rb
+++ b/spec/lita/adapters/slack/slack_user_spec.rb
@@ -6,7 +6,9 @@ describe Lita::Adapters::Slack::SlackUser do
       "id" => "U023BECGF",
       "name" => "bobby",
       "real_name" => "Bobby Tables",
-      "email" => "btables@example.com"
+      "profile" => {
+        "email" => "btables@example.com"
+      }
     }
   end
   let(:user_data_2) do
@@ -28,15 +30,15 @@ describe Lita::Adapters::Slack::SlackUser do
       expect(subject[0].id).to eq('U023BECGF')
       expect(subject[0].name).to eq('bobby')
       expect(subject[0].real_name).to eq('Bobby Tables')
-      expect(subject[0].email).to eq('btables@example.com')
+      expect(subject[0].profile['email']).to eq('btables@example.com')
       expect(subject[1].id).to eq('U024BE7LH')
       expect(subject[1].name).to eq('carl')
       expect(subject[1].real_name).to eq('')
-      expect(subject[1].email).to eq('')
+      expect(subject[1].profile['email']).to eq('')
     end
 
     it "raw_data matches the metadata" do
-      expect(subject[0].metadata['email']).to eq(subject[0].raw_data['email'])
+      expect(subject[0].metadata['name']).to eq(subject[0].raw_data['name'])
     end
   end
 end

--- a/spec/lita/adapters/slack/user_creator_spec.rb
+++ b/spec/lita/adapters/slack/user_creator_spec.rb
@@ -14,15 +14,16 @@ describe Lita::Adapters::Slack::UserCreator do
   describe ".create_users" do
     let(:real_name) { 'Bobby Tables' }
     let(:email) { 'bobby@example.com' }
-    let(:bobby) { Lita::Adapters::Slack::SlackUser.new('U023BECGF', 'bobby', real_name, slack_data) }
     let(:robot_id) { 'U12345678' }
-    let(:slack_data) { { 'id' => 'U023BECGF', 'name' => 'bobby', 'real_name' => real_name, 'email' => email } }
+    let(:slack_data) { { 'id' => 'U023BECGF', 'name' => 'bobby', 'real_name' => real_name, 'profile' => { 'email' => email } } }
+    let(:bobby) { Lita::Adapters::Slack::SlackUser.new('U023BECGF', 'bobby', real_name, slack_data) }
 
     it "creates Lita users for each user in the provided data" do
       expect(Lita::User).to receive(:create).with(
         'U023BECGF',
         name: 'Bobby Tables',
-        mention_name: 'bobby'
+        mention_name: 'bobby',
+        email: 'bobby@example.com'
       )
       expect(robot).to receive(:trigger).with(
         :slack_user_created,
@@ -39,7 +40,8 @@ describe Lita::Adapters::Slack::UserCreator do
         expect(Lita::User).to receive(:create).with(
           'U023BECGF',
           name: 'bobby',
-          mention_name: 'bobby'
+          mention_name: 'bobby',
+          email: 'bobby@example.com'
         )
 
         described_class.create_users([bobby], robot, robot_id)
@@ -49,7 +51,7 @@ describe Lita::Adapters::Slack::UserCreator do
 
   describe ".create_user" do
     let(:robot_id) { 'U12345678' }
-    let(:slack_data) { { 'id' => robot_id, 'name' => 'litabot', 'real_name' => 'Lita Bot', 'email' => 'litabot@example.com' } }
+    let(:slack_data) { { 'id' => robot_id, 'name' => 'litabot', 'real_name' => 'Lita Bot', 'profile' => { 'email' => 'litabot@example.com' } } }
     let(:slack_user) { Lita::Adapters::Slack::SlackUser.new(robot_id, 'litabot', 'Lita Bot', slack_data) }
 
     it "updates the robot's name and mention name if it applicable" do


### PR DESCRIPTION
Added a way to get profile information into the lita user object.  More values can also follow the same convention to add more items.