### PR TITLE
Properly set the room name in received messages

### DIFF
--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -113,7 +113,8 @@ module Lita
         end
 
         def dispatch_message(user)
-          source = Source.new(user: user, room: channel)
+          room = Lita::Room.find_by_id(channel)
+          source = Source.new(user: user, room: room || channel)
           source.private_message! if channel && channel[0] == "D"
           message = Message.new(robot, body, source)
           message.command! if source.private_message?

--- a/spec/lita/adapters/slack/message_handler_spec.rb
+++ b/spec/lita/adapters/slack/message_handler_spec.rb
@@ -37,12 +37,14 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
       let(:message) { instance_double('Lita::Message', command!: false, extensions: {}) }
       let(:source) { instance_double('Lita::Source', private_message?: false) }
       let(:user) { instance_double('Lita::User', id: 'U023BECGF') }
+      let(:room) { instance_double('Lita::Room', id: "C2147483705", name: "general") }
 
       before do
         allow(Lita::User).to receive(:find_by_id).and_return(user)
+        allow(Lita::Room).to receive(:find_by_id).and_return(room)
         allow(Lita::Source).to receive(:new).with(
           user: user,
-          room: "C2147483705"
+          room: room
         ).and_return(source)
         allow(Lita::Message).to receive(:new).with(robot, "Hello", source).and_return(message)
         allow(robot).to receive(:receive).with(message)
@@ -69,6 +71,7 @@ describe Lita::Adapters::Slack::MessageHandler, lita: true do
         end
 
         before do
+          allow(Lita::Room).to receive(:find_by_id).and_return(nil)
           allow(Lita::Source).to receive(:new).with(
             user: user,
             room: "D2147483705"


### PR DESCRIPTION
@jimmycuadra This should fix #44.

Before, the channel ID was being set as both the `id` and `name` within the message's `room_object`.

This PR will either lookup the correct room object, which would have a name, or it will assign the channel ID as a fallback (which will happen when it's a private conversation without a name). This relies on [`Lita::Source` accepting either a `Lita::Room` or a `String`](https://github.com/litaio/lita/blob/63c0aea704202ae1e7d5021ec14ad51e8bb1735a/lib/lita/source.rb#L43-L49).