### PR TITLE
Several bugfixes for improper closing of websocket and eventmachine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ test/tmp
 test/version_tmp
 tmp
 lita_config.rb
-.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ test/tmp
 test/version_tmp
 tmp
 lita_config.rb
+.idea/

--- a/lib/lita/adapters/slack/event_loop.rb
+++ b/lib/lita/adapters/slack/event_loop.rb
@@ -15,7 +15,11 @@ module Lita
           end
 
           def safe_stop
-            EM.stop if EM.reactor_running?
+            EM.stop if running?
+          end
+
+          def running?
+            EM.reactor_running? && !EM.stopping?
           end
         end
       end

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -49,7 +49,7 @@ module Lita
             websocket.on(:message) { |event| receive_message(event) }
             websocket.on(:close) do
               log.info("Disconnected from Slack.")
-              shut_down
+              EventLoop.safe_stop
             end
             websocket.on(:error) { |event| log.debug("WebSocket error: #{event.message}") }
 
@@ -64,7 +64,7 @@ module Lita
         end
 
         def shut_down
-          if websocket
+          if websocket_open?
             log.debug("Closing connection to the Slack Real Time Messaging API.")
             websocket.close
           end
@@ -115,6 +115,13 @@ module Lita
           options[:proxy] = { :origin => config.proxy } if config.proxy
           options
         end
+
+        # States are defined in https://github.com/faye/faye-websocket-ruby/blob/master/lib/faye/websocket/api.rb
+        # Currently, it's the best available option to inspect websocket state
+        def websocket_open?
+          websocket && websocket.ready_state <= 1
+        end
+
       end
     end
   end

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -64,7 +64,7 @@ module Lita
         end
 
         def shut_down
-          if websocket_open?
+          if websocket && EventLoop.running?
             log.debug("Closing connection to the Slack Real Time Messaging API.")
             websocket.close
           end
@@ -114,12 +114,6 @@ module Lita
           options = { ping: 10 }
           options[:proxy] = { :origin => config.proxy } if config.proxy
           options
-        end
-
-        # States are defined in https://github.com/faye/faye-websocket-ruby/blob/master/lib/faye/websocket/api.rb
-        # Currently, it's the best available option to inspect websocket state
-        def websocket_open?
-          websocket && websocket.ready_state <= 1
         end
 
       end

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -29,7 +29,7 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
   end
   let(:token) { 'abcd-1234567890-hWYd21AmMH2UHAkx29vb5c1Y' }
   let(:queue) { Queue.new }
-  let(:proxy_url) { "http://foo:3128" }
+  let(:proxy_url) { "http://example.com:3128" }
   let(:config) { Lita::Adapters::Slack.configuration_builder.build }
 
   before do
@@ -114,6 +114,16 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
       # the WebSocket.
       subject.send(:receive_message, event)
     end
+
+    context "when the WebSocket is closed from outside" do
+      it "shuts down the reactor" do
+        with_websocket(subject, queue) do |websocket|
+            websocket.close
+            expect(EM.stopping?).to be_truthy
+          end
+      end
+    end
+
   end
 
   describe "#send_messages" do

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -136,6 +136,7 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
       allow(Faye::WebSocket::Client).to receive(:new).and_return(websocket)
       allow(websocket).to receive(:on)
       allow(websocket).to receive(:close)
+      allow(websocket).to receive(:ready_state).and_return(1)
       allow(Lita::Adapters::Slack::EventLoop).to receive(:defer).and_yield
     end
 

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -136,7 +136,6 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
       allow(Faye::WebSocket::Client).to receive(:new).and_return(websocket)
       allow(websocket).to receive(:on)
       allow(websocket).to receive(:close)
-      allow(websocket).to receive(:ready_state).and_return(1)
       allow(Lita::Adapters::Slack::EventLoop).to receive(:defer).and_yield
     end
 


### PR DESCRIPTION
Couple of fixes to different issues in shut down logic that all lead to such errors in different scenarios:  
`RuntimeError: eventmachine not initialized: evma_install_oneshot_timer`

1) There's a problem with shutting down strategy introduced in this commit:
https://github.com/litaio/lita-slack/commit/b27046fb13bbe59fc31ad27d0fdf16b63077f712
the `shut_down` method that has been added to `:close` callback on websocket, tries to close websocket itself, triggering shutdown logic twice and attempting to turn off the EM twice as well, with the second attempt failing. To make it happen only once, I've substituted it with direct EM shutting down command.
2) Websocket ensures to be closed itself, when EM, where it operates on, is shut down: https://github.com/faye/faye-websocket-ruby/blob/39e26115b39c83e923dc0656548fad52dd736956/lib/faye/websocket/client.rb#L85
And in the same time, websocket is not suited to receive `close` instruction outside the EM loop:
https://github.com/faye/faye-websocket-ruby/blob/39e26115b39c83e923dc0656548fad52dd736956/lib/faye/websocket/api.rb#L92
This leads us to necessity to check, whether EM is running before trying to close socket. I've added it. 
Also, I consider this fix to be the most important one, since that's how Lita itself handles interrupts:
https://github.com/litaio/lita/blob/e9abbce2aed0a6659e96250bb6a0b576ec306fdd/lib/lita/robot.rb#L128
Shortly, it makes EM loop in lita-slack to finish and only after that, it runs the `shut_down` which will fail on exception with current implementation, since there no working EM anymore.
3) Fixed race condition in test for websocket through a proxy. Shortly, the url used there (`http://foo:3128`) made websocket throw exception here: https://github.com/faye/faye-websocket-ruby/blob/master/lib/faye/websocket/client.rb#L50 which immediately kicked off the shutdown procedure for the socket and after that, for the whole EM. Sometimes it has been forcing it to finish before the `shutdown` call in the test helper and also resulted in this error.
4) Also, bringing back a test, that has been removed, but which covered one of such cases:
https://github.com/litaio/lita-slack/commit/65e8b2f07a5b9017bc2bb962d7d7e855937cfa4a

Please, don't hesitate to contact me for clarifications.