### PR TITLE
added dialog.open method

### DIFF
--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -55,6 +55,14 @@ module Lita
           )
         end
 
+        def open_dialog(dialog, trigger_id)
+          call_api(
+            "dialog.open",
+            dialog: MultiJson.dump(dialog),
+            trigger_id: trigger_id,
+          )
+        end
+
         def send_messages(channel_id, messages)
           call_api(
             "chat.postMessage",

--- a/lib/lita/adapters/slack/chat_service.rb
+++ b/lib/lita/adapters/slack/chat_service.rb
@@ -23,6 +23,13 @@ module Lita
           api.send_attachments(target, Array(attachments))
         end
         alias_method :send_attachment, :send_attachments
+
+        # @param dialog The dialog to be shown to the user
+        # @param trigger_id The trigger id of a slash command request URL or interactive message
+        # @return [void]
+        def open_dialog(dialog, trigger_id)
+          api.open_dialog(dialog, trigger_id)
+        end
       end
     end
   end


### PR DESCRIPTION
Supports the new `dialog.open` method. A new method was created in the api and `chat_service` to enable this feature.

[documentation about dialog.open](https://api.slack.com/methods/dialog.open)

Documentation about trigger_id from [Slack documentation](https://api.slack.com/docs/permissions-api):
> **Your app receives a `trigger_id`**
> When that interaction occurs, your slash command request URL or interactive message request URL will receive a standard payload with a bonus field called `trigger_id`.
>
> A `trigger_id` is an artifact of interaction between the user and your app. Use it soon after receiving to draw a theoretical dotted line between the interaction and your requesting permissions.