### PR TITLE
Proposal - add threading & reactions to Slack

### DIFF
--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -42,21 +42,27 @@ module Lita
       def send_messages(target, messages)
         api = API.new(config)
 
-        emoji_ts = target.try(:timestamp)
+        channel = channel_for(target)
+        timestamp = target.try(:timestamp)
         thread_ts = target.try(:thread_ts)
 
         strings = messages.select { |s| s.is_a?(String) }
         symbols = messages.select { |s| s.is_a?(Symbol) }
 
         symbols.each do |s|
-          api.react_with_emoji(channel_for(target), s.to_s, emoji_ts)
-        end if emoji_ts
+          api.react_with_emoji(channel, s.to_s, timestamp)
+        end if timestamp
+
+        if strings[0] && strings[0][0] == '…'
+          thread_ts = timestamp
+          strings[0] = strings[0][1..-1]
+        end
 
         if strings.any?
           if thread_ts
-            api.reply_in_thread(channel_for(target), strings, thread_ts)
+            api.reply_in_thread(channel, strings, thread_ts)
           else
-            api.send_messages(channel_for(target), strings)
+            api.send_messages(channel, strings)
           end
         end
       end

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -40,7 +40,12 @@ module Lita
 
       def send_messages(target, strings)
         api = API.new(config)
-        api.send_messages(channel_for(target), strings)
+
+        if target.thread_ts
+          api.reply_in_thread(channel_for(target), strings, target.thread_ts)
+        else
+          api.send_messages(channel_for(target), strings)
+        end
       end
 
       def set_topic(target, topic)

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -38,13 +38,23 @@ module Lita
         room_roster target.id, api
       end
 
-      def send_messages(target, strings)
+      # @param [Array] messages list of String messages or Symbol emoji reactions
+      def send_messages(target, messages)
         api = API.new(config)
 
-        if target.thread_ts
-          api.reply_in_thread(channel_for(target), strings, target.thread_ts)
-        else
-          api.send_messages(channel_for(target), strings)
+        strings = messages.select { |s| s.is_a?(String) }
+        symbols = messages.select { |s| s.is_a?(Symbol) }
+
+        symbols.each do |s|
+          api.react_with_emoji(channel_for(target), s.to_s, target.timestamp)
+        end
+
+        if strings.any?
+          if target.thread_ts
+            api.reply_in_thread(channel_for(target), strings, target.thread_ts)
+          else
+            api.send_messages(channel_for(target), strings)
+          end
         end
       end
 

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -42,16 +42,19 @@ module Lita
       def send_messages(target, messages)
         api = API.new(config)
 
+        emoji_ts = target.try(:timestamp)
+        thread_ts = target.try(:thread_ts)
+
         strings = messages.select { |s| s.is_a?(String) }
         symbols = messages.select { |s| s.is_a?(Symbol) }
 
         symbols.each do |s|
-          api.react_with_emoji(channel_for(target), s.to_s, target.timestamp)
-        end
+          api.react_with_emoji(channel_for(target), s.to_s, emoji_ts)
+        end if emoji_ts
 
         if strings.any?
-          if target.thread_ts
-            api.reply_in_thread(channel_for(target), strings, target.thread_ts)
+          if thread_ts
+            api.reply_in_thread(channel_for(target), strings, thread_ts)
           else
             api.send_messages(channel_for(target), strings)
           end

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -55,6 +55,16 @@ module Lita
           )
         end
 
+        def reply_in_thread(channel_id, messages, thread_ts)
+          call_api(
+            "chat.postMessage",
+            as_user: true,
+            channel: channel_id,
+            text: messages,
+            thread_ts: thread_ts
+          )
+        end
+
         def send_messages(channel_id, messages)
           call_api(
             "chat.postMessage",

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -75,6 +75,17 @@ module Lita
           )
         end
 
+        def react_with_emoji(channel_id, emoji, ts)
+          call_api(
+            "reactions.add",
+            **post_message_config,
+            as_user: true,
+            channel: channel_id,
+            name: emoji,
+            timestamp: ts
+          )
+        end
+
         def set_topic(channel, topic)
           call_api("channels.setTopic", channel: channel, topic: topic)
         end

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -4,6 +4,7 @@ require 'lita/adapters/slack/team_data'
 require 'lita/adapters/slack/slack_im'
 require 'lita/adapters/slack/slack_user'
 require 'lita/adapters/slack/slack_channel'
+require 'lita/adapters/slack/slack_source'
 
 module Lita
   module Adapters
@@ -60,7 +61,7 @@ module Lita
             "chat.postMessage",
             as_user: true,
             channel: channel_id,
-            text: messages,
+            text: messages.join("\n"),
             thread_ts: thread_ts
           )
         end

--- a/lib/lita/adapters/slack/chat_service.rb
+++ b/lib/lita/adapters/slack/chat_service.rb
@@ -23,6 +23,10 @@ module Lita
           api.send_attachments(target, Array(attachments))
         end
         alias_method :send_attachment, :send_attachments
+
+        def reply_in_thread(channel_id, messages, thread_ts)
+          api.reply_in_thread(channel_id,  messages.join("\n"), thread_ts)
+        end
       end
     end
   end

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -114,12 +114,13 @@ module Lita
 
         def dispatch_message(user)
           room = Lita::Room.find_by_id(channel)
-          source = Source.new(user: user, room: room || channel)
+          extensions = { timestamp: data["ts"] }
+          extensions[:thread_ts] = data["thread_ts"] if data["thread_ts"]
+          source = SlackSource.new(user: user, room: room || channel, extensions: extensions)
           source.private_message! if channel && channel[0] == "D"
           message = Message.new(robot, body, source)
           message.command! if source.private_message?
-          message.extensions[:slack] = { timestamp: data["ts"] }
-          message.extensions[:slack][:thread_ts] = data["thread_ts"] if data["thread_ts"]
+          message.extensions[:slack] = extensions
           log.debug("Dispatching message to Lita from #{user.id}.")
           robot.receive(message)
         end

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -119,6 +119,7 @@ module Lita
           message = Message.new(robot, body, source)
           message.command! if source.private_message?
           message.extensions[:slack] = { timestamp: data["ts"] }
+          message.extensions[:slack][:thread_ts] = data["thread_ts"] if data["thread_ts"]
           log.debug("Dispatching message to Lita from #{user.id}.")
           robot.receive(message)
         end

--- a/lib/lita/adapters/slack/slack_source.rb
+++ b/lib/lita/adapters/slack/slack_source.rb
@@ -1,0 +1,25 @@
+module Lita
+  module Adapters
+    class Slack < Adapter
+      # A struct representing a Slack message source. It has access to
+      # extensions of the original message from the source, which enables
+      # reacting with emoji or replying in threads.
+      #
+      # @api public
+      class SlackSource < Lita::Source
+        def initialize(**kwargs)
+          @extensions = kwargs.delete(:extensions)
+          super(**kwargs)
+        end
+
+        def timestamp
+          @extensions[:timestamp]
+        end
+
+        def thread_ts
+          @extensions[:thread_ts]
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This isn't finished; think of it more as a proposal, which we'll be happy to clean up if you like the idea.

Our goal is to let our bot use some advanced Slack features, namely:
 - replying to threaded messages in the same thread where they appeared
 - starting a new thread to reply to _some_ messages
 - replying with an emoji reaction in addition to, or instead of, a chat message

We wanted to do all three of these things without modifying the Lita core. To accomplish that, we added a `SlackSource` which subclasses `Lita::Source` and adds Slack extensions; when the Slack adapter processes messages, it instantiates `SlackSource` so that when its own methods are called back, it can rely on the extra state tucked away inside the source. (Naturally, it gracefully degrades if you pass a vanilla `Source` into the adapter.)

The adapter itself has gotten some new, Slack-specific methods to `react_with_emoji`, `reply_in_thread`, and so forth. However, all of these are obscured from the bot's handlers. Instead, we have introduced two new conventions inside the adapter's `send_messages`, since this is the "nexus" of message sending which allows our conventions to apply to all of the ways that Lita has to send messages.

The two conventions are:
 - Sending a `Symbol` instead of ` String` message, causes an emoji reaction to the source.
 - Any message beginning with the Unicode ellipses character `…` is sent in a thread of the original message (i.e. it begins a new thread even if the original message was top-level)

In addition, because SlackSource tracks threadiness, _any_ reply to a threaded SlackSource will be made in the same thread.

We're interested in your feedback on the way we have implemented these things, and happy to clean up our implementation and add tests once we've heard your thoughts. My own observations:

1) It seems a bit weird to incorporate notions of "thread" and "reaction" into Lita's core, so the use of message-formatting conventions is probably a good idea, to keep the core adapter-agnostic. Both of these conventions work sensibly when used with adapters that don't support them.

2) It seems dirty that we need to use a special `SlackSource` to track extensions. If the `Source` class kept track of extensions, or pointed to the original `Message`, we could get rid of the subclass.