### PR TITLE
Enable Lita to handle messages from other bots (again)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ gem "lita-slack"
 * `proxy` (String) – Specify a HTTP proxy URL. (e.g. "http://squid.example.com:3128")
 * `unfurl_links` (Boolean) – Set to `true` to automatically add previews for all links in messages sent by Lita.
 * `unfurl_media` (Boolean) – Set to `false` to prevent automatic previews for media files in messages sent by Lita.
+* `handle_bot_messages` (Boolean) - Set to `false` to prevent Lita from handling messages from other bots.
 
 **Note**: When using lita-slack, the adapter will overwrite the bot's name and mention name with the values set on the server, so `config.robot.name` and `config.robot.mention_name` will have no effect.
 

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -13,6 +13,7 @@ module Lita
       config :link_names, type: [true, false]
       config :unfurl_links, type: [true, false]
       config :unfurl_media, type: [true, false]
+      config :handle_bot_messages, type: [true, false], default: true
 
       # Provides an object for Slack-specific features.
       def chat_service

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -3,9 +3,10 @@ module Lita
     class Slack < Adapter
       # @api private
       class MessageHandler
-        def initialize(robot, robot_id, data)
+        def initialize(robot, robot_id, config, data)
           @robot = robot
           @robot_id = robot_id
+          @config = config
           @data = data
           @type = data["type"]
         end
@@ -196,7 +197,7 @@ module Lita
 
         # Types of messages Lita should dispatch to handlers.
         def supported_message_subtypes
-          %w(me_message)
+          %w(me_message) + (@config.handle_bot_messages ? %w(bot_message) : [])
         end
 
         def supported_subtype?

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -97,7 +97,7 @@ module Lita
         def receive_message(event)
           data = MultiJson.load(event.data)
 
-          EventLoop.defer { MessageHandler.new(robot, robot_id, data).handle }
+          EventLoop.defer { MessageHandler.new(robot, robot_id, config, data).handle }
         end
 
         def safe_payload_for(channel, string)

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -104,6 +104,7 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
       allow(Lita::Adapters::Slack::MessageHandler).to receive(:new).with(
         robot,
         'U12345678',
+        config,
         {},
       ).and_return(message_handler)
 


### PR DESCRIPTION
After upgrading our branch to include 1.8.0 AND #64, our Lita bot stopped responding to messages from other bots. This is because `bot_message` is not in the whitelist of supported message subtypes.

I suspect this may have been a deliberate change, however we have a number of systems that invoke actions on Lita through Slack. I’ve added a configuration option to re-enable these interactions.

Some thoughts:
1. I’m happy to make the default value `false` if you prefer, since this is now the default behavior since sometime after 1.7.2. 
1. I’m also happy to change the name of the config option. I’m not crazy about `handle_bot_messages`, to be honest.