### PR TITLE
Add supports for slack_team_joined events

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Lita will join your default channel after initial setup. To have it join additio
 * `:slack_reaction_added` - When a reaction has been added to a previous message. The payload includes `:user` (a `Lita::User` for the sender of the message in question), `:name` (the string name of the reaction added), `:item_user` (a `Lita::User` for the user that created the original item that has been reacted to), `:item` (a hash of raw data from Slack about the message), and `:event_ts` (a string timestamp used to identify the message).
 * `:slack_reaction_removed` - When a reaction has been removed from a previous message. The payload is the same as the `:slack_reaction_added` message.
 * `:slack_user_created` - When the robot creates/updates a user's info - name, mention name, etc., as directed by Slack. The payload has a single object, a `Lita::Slack::Adapters::SlackUser` object, under the `:slack_user` key.
+* `:slack_team_joined` - When a new user joins slack. Is triggered in addition to `:slack_user_created` with the same payload
 
 ## Chat service API
 

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -18,8 +18,10 @@ module Lita
             handle_message
           when "reaction_added", "reaction_removed"
             handle_reaction
-          when "user_change", "team_join"
+          when "user_change"
             handle_user_change
+          when "team_join"
+            handle_team_join
           when "bot_added", "bot_changed"
             handle_bot_change
           when "channel_created", "channel_rename", "group_rename"
@@ -188,6 +190,15 @@ module Lita
         def handle_user_change
           log.debug("Updating user data.")
           UserCreator.create_user(SlackUser.from_data(data["user"]), robot, robot_id)
+        end
+
+        def handle_team_join
+          log.debug("Updating user data. New user joined slack")
+
+          slack_user = SlackUser.from_data(data["user"])
+
+          UserCreator.create_user(slack_user, robot, robot_id)
+          robot.trigger(:slack_team_joined, slack_user: slack_user)
         end
 
         def log


### PR DESCRIPTION
In order to make a greeting plugin, I need the `team_join` event. This is my attempt at adding support for it.