### PR TITLE
New user lookup api

### DIFF
--- a/lib/lita-slack.rb
+++ b/lib/lita-slack.rb
@@ -4,4 +4,4 @@ Lita.load_locales Dir[File.expand_path(
   File.join("..", "..", "locales", "*.yml"), __FILE__
 )]
 
-require "lita/adapters/slack"
+require_relative "lita/adapters/slack"

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -1,5 +1,5 @@
-require 'lita/adapters/slack/chat_service'
-require 'lita/adapters/slack/rtm_connection'
+require_relative 'slack/chat_service'
+require_relative 'slack/rtm_connection'
 
 module Lita
   module Adapters

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -41,9 +41,9 @@ module Lita
       def send_messages(target, strings)
         api = API.new(config)
         if target.respond_to?(:thread)
-          api.send_messages(target.room, strings, thread_ts: target.thread)
+          api.send_messages(target.room || target.user&.id, strings, thread_ts: target.thread)
         else
-          api.send_messages(target.room, strings)
+          api.send_messages(target.room || target.user&.id, strings)
         end
       end
 

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -40,7 +40,7 @@ module Lita
 
       def send_messages(target, strings)
         api = API.new(config)
-        api.send_messages(target.room, strings)
+        api.send_messages(target.room, strings, thread_ts: target.thread)
       end
 
       def set_topic(target, topic)

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -40,7 +40,11 @@ module Lita
 
       def send_messages(target, strings)
         api = API.new(config)
-        api.send_messages(target.room, strings, thread_ts: (target.thread if target.respond_to?(:thread)))
+        if target.respond_to?(:thread)
+          api.send_messages(target.room, strings, thread_ts: target.thread)
+        else
+          api.send_messages(target.room, strings)
+        end
       end
 
       def set_topic(target, topic)

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -40,7 +40,7 @@ module Lita
 
       def send_messages(target, strings)
         api = API.new(config)
-        api.send_messages(target.room, strings, thread_ts: target.thread)
+        api.send_messages(target.room, strings, thread_ts: (target.thread if target.respond_to?(:thread)))
       end
 
       def set_topic(target, topic)

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -40,11 +40,7 @@ module Lita
 
       def send_messages(target, strings)
         api = API.new(config)
-        if target.respond_to?(:thread)
-          api.send_messages(target.room, strings, thread_ts: target.thread)
-        else
-          api.send_messages(target.room, strings)
-        end
+        api.send_messages(target.room, strings, thread_ts: (target.thread if target.respond_to?(:thread)))
       end
 
       def set_topic(target, topic)

--- a/lib/lita/adapters/slack.rb
+++ b/lib/lita/adapters/slack.rb
@@ -40,7 +40,7 @@ module Lita
 
       def send_messages(target, strings)
         api = API.new(config)
-        api.send_messages(channel_for(target), strings)
+        api.send_messages(target.room, strings)
       end
 
       def set_topic(target, topic)
@@ -59,14 +59,6 @@ module Lita
       private
 
       attr_reader :rtm_connection
-
-      def channel_for(target)
-        if target.private_message?
-          rtm_connection.im_for(target.user.id)
-        else
-          target.room
-        end
-      end
 
       def channel_roster(room_id, api)
         response = api.channels_info room_id

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -46,6 +46,10 @@ module Lita
           call_api("im.list")
         end
 
+        def user_info( user_id )
+          call_api("users.info", user: user_id)
+        end
+
         def send_attachments(room_or_user, attachments)
           call_api(
             "chat.postMessage",

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -55,14 +55,15 @@ module Lita
           )
         end
 
-        def send_messages(channel_id, messages)
-          call_api(
-            "chat.postMessage",
-            **post_message_config,
-            as_user: true,
+        def send_messages(channel_id, messages, additional_payload = {})
+          data = {
             channel: channel_id,
+            as_user: true,
             text: messages.join("\n"),
-          )
+          }.merge(post_message_config)
+           .merge(additional_payload)
+
+          call_api( "chat.postMessage", data )
         end
 
         def set_topic(channel, topic)

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -1,9 +1,9 @@
 require 'faraday'
 
-require 'lita/adapters/slack/team_data'
-require 'lita/adapters/slack/slack_im'
-require 'lita/adapters/slack/slack_user'
-require 'lita/adapters/slack/slack_channel'
+require_relative 'team_data'
+require_relative 'slack_im'
+require_relative 'slack_user'
+require_relative 'slack_channel'
 
 module Lita
   module Adapters

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -62,7 +62,6 @@ module Lita
             text: messages.join("\n"),
           }.merge(post_message_config)
            .merge(additional_payload)
-          p data
 
           call_api( "chat.postMessage", **data )
         end

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -63,7 +63,7 @@ module Lita
           }.merge(post_message_config)
            .merge(additional_payload)
 
-          call_api( "chat.postMessage", data )
+          call_api( "chat.postMessage", **data )
         end
 
         def set_topic(channel, topic)

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -62,6 +62,7 @@ module Lita
             text: messages.join("\n"),
           }.merge(post_message_config)
            .merge(additional_payload)
+          p data
 
           call_api( "chat.postMessage", **data )
         end

--- a/lib/lita/adapters/slack/api.rb
+++ b/lib/lita/adapters/slack/api.rb
@@ -69,15 +69,16 @@ module Lita
           call_api("channels.setTopic", channel: channel, topic: topic)
         end
 
-        def rtm_start
-          response_data = call_api("rtm.start")
+        def rtm_connect
+          response_data = call_api("rtm.connect")
+
+          raise RuntimeError, response_data["error"] if response_data["ok"] != true
 
           TeamData.new(
-            SlackIM.from_data_array(response_data["ims"]),
+            response_data["team"]["id"],
+            response_data["team"]["name"],
+            response_data["team"]["domain"],
             SlackUser.from_data(response_data["self"]),
-            SlackUser.from_data_array(response_data["users"]),
-            SlackChannel.from_data_array(response_data["channels"]) +
-              SlackChannel.from_data_array(response_data["groups"]),
             response_data["url"],
           )
         end

--- a/lib/lita/adapters/slack/chat_service.rb
+++ b/lib/lita/adapters/slack/chat_service.rb
@@ -1,4 +1,4 @@
-require "lita/adapters/slack/attachment"
+require_relative "attachment"
 
 module Lita
   module Adapters

--- a/lib/lita/adapters/slack/message_handler.rb
+++ b/lib/lita/adapters/slack/message_handler.rb
@@ -1,3 +1,5 @@
+require_relative 'slack_source'
+
 module Lita
   module Adapters
     class Slack < Adapter
@@ -112,9 +114,13 @@ module Lita
           data["channel"]
         end
 
+        def thread
+          data["thread_ts"]
+        end
+
         def dispatch_message(user)
           room = Lita::Room.find_by_id(channel)
-          source = Source.new(user: user, room: room || channel)
+          source = SlackSource.new(user: user, room: room || channel, thread: thread)
           source.private_message! if channel && channel[0] == "D"
           message = Message.new(robot, body, source)
           message.command! if source.private_message?

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -28,10 +28,6 @@ module Lita
           @robot_id = team_data.self.id
         end
 
-        def im_for(user_id)
-          im_mapping.im_for(user_id)
-        end
-
         def run(queue = nil, options = {})
           EventLoop.run do
             log.debug("Connecting to the Slack Real Time Messaging API.")

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -17,19 +17,15 @@ module Lita
 
         class << self
           def build(robot, config)
-            new(robot, config, API.new(config).rtm_start)
+            new(robot, config, API.new(config).rtm_connect)
           end
         end
 
         def initialize(robot, config, team_data)
           @robot = robot
           @config = config
-          @im_mapping = IMMapping.new(API.new(config), team_data.ims)
           @websocket_url = team_data.websocket_url
           @robot_id = team_data.self.id
-
-          UserCreator.create_users(team_data.users, robot, robot_id)
-          RoomCreator.create_rooms(team_data.channels, robot)
         end
 
         def im_for(user_id)

--- a/lib/lita/adapters/slack/rtm_connection.rb
+++ b/lib/lita/adapters/slack/rtm_connection.rb
@@ -1,12 +1,12 @@
 require 'faye/websocket'
 require 'multi_json'
 
-require 'lita/adapters/slack/api'
-require 'lita/adapters/slack/event_loop'
-require 'lita/adapters/slack/im_mapping'
-require 'lita/adapters/slack/message_handler'
-require 'lita/adapters/slack/room_creator'
-require 'lita/adapters/slack/user_creator'
+require_relative 'api'
+require_relative 'event_loop'
+require_relative 'im_mapping'
+require_relative 'message_handler'
+require_relative 'room_creator'
+require_relative 'user_creator'
 
 module Lita
   module Adapters

--- a/lib/lita/adapters/slack/slack_source.rb
+++ b/lib/lita/adapters/slack/slack_source.rb
@@ -1,0 +1,15 @@
+module Lita
+  module Adapters
+    class Slack < Adapter
+      # @api private
+      class SlackSource < Lita::Source
+        attr_reader :thread
+
+        def initialize( user: nil, room: nil, private_message: nil, thread: nil )
+          super( user: user, room: room, private_message: private_message )
+          @thread = thread
+        end
+      end
+    end
+  end
+end

--- a/lib/lita/adapters/slack/team_data.rb
+++ b/lib/lita/adapters/slack/team_data.rb
@@ -2,7 +2,7 @@ module Lita
   module Adapters
     # @api private
     class Slack < Adapter
-      TeamData = Struct.new(:ims, :self, :users, :channels, :websocket_url)
+      TeamData = Struct.new(:id, :name, :domain, :self, :websocket_url)
     end
   end
 end

--- a/lita-slack.gemspec
+++ b/lita-slack.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "lita", ">= 4.7.1"
   spec.add_runtime_dependency "multi_json"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rack-test"
   spec.add_development_dependency "rake"

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -637,11 +637,11 @@ describe Lita::Adapters::Slack::API do
     end
   end
 
-  describe "#rtm_start" do
+  describe "#rtm_connect" do
     let(:http_status) { 200 }
     let(:stubs) do
       Faraday::Adapter::Test::Stubs.new do |stub|
-        stub.post('https://slack.com/api/rtm.start', token: token) do
+        stub.post('https://slack.com/api/rtm.connect', token: token) do
           [http_status, {}, http_response]
         end
       end
@@ -652,11 +652,8 @@ describe Lita::Adapters::Slack::API do
         MultiJson.dump({
           ok: true,
           url: 'wss://example.com/',
-          users: [{ id: 'U023BECGF' }],
-          ims: [{ id: 'D024BFF1M' }],
           self: { id: 'U12345678' },
-          channels: [{ id: 'C1234567890' }],
-          groups: [{ id: 'G0987654321' }],
+          team: { id: 'T0987654321' },
         })
       end
 
@@ -664,18 +661,6 @@ describe Lita::Adapters::Slack::API do
         response = subject.rtm_connect
 
         expect(response.self.id).to eq('U12345678')
-      end
-
-      it "has an array of IMs" do
-        response = subject.rtm_connect
-
-        expect(response.ims[0].id).to eq('D024BFF1M')
-      end
-
-      it "has an array of users" do
-        response = subject.rtm_connect
-
-        expect(response.users[0].id).to eq('U023BECGF')
       end
 
       it "has a WebSocket URL" do

--- a/spec/lita/adapters/slack/api_spec.rb
+++ b/spec/lita/adapters/slack/api_spec.rb
@@ -661,25 +661,25 @@ describe Lita::Adapters::Slack::API do
       end
 
       it "has data on the bot user" do
-        response = subject.rtm_start
+        response = subject.rtm_connect
 
         expect(response.self.id).to eq('U12345678')
       end
 
       it "has an array of IMs" do
-        response = subject.rtm_start
+        response = subject.rtm_connect
 
         expect(response.ims[0].id).to eq('D024BFF1M')
       end
 
       it "has an array of users" do
-        response = subject.rtm_start
+        response = subject.rtm_connect
 
         expect(response.users[0].id).to eq('U023BECGF')
       end
 
       it "has a WebSocket URL" do
-        response = subject.rtm_start
+        response = subject.rtm_connect
 
         expect(response.websocket_url).to eq('wss://example.com/')
       end

--- a/spec/lita/adapters/slack/rtm_connection_spec.rb
+++ b/spec/lita/adapters/slack/rtm_connection_spec.rb
@@ -39,7 +39,7 @@ describe Lita::Adapters::Slack::RTMConnection, lita: true do
   describe ".build" do
     before do
       allow(Lita::Adapters::Slack::API).to receive(:new).with(config).and_return(api)
-      allow(api).to receive(:rtm_start).and_return(rtm_start_response)
+      allow(api).to receive(:rtm_connect).and_return(rtm_start_response)
     end
 
     it "constructs a new RTMConnection with the results of rtm.start data" do

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -150,7 +150,7 @@ describe Lita::Adapters::Slack, lita: true do
 
       context "with optional thread" do
         it "sends the message to the Web API without thread_ts" do
-          expect(api).to receive(:send_messages).with(private_message_source.room, ['foo'])
+          expect(api).to receive(:send_messages).with(private_message_source.room, ['foo'], { thread_ts: nil })
 
           subject.send_messages(private_message_source, ['foo'])
         end

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -147,6 +147,14 @@ describe Lita::Adapters::Slack, lita: true do
           subject.send_messages(room_source, ['foo'])
         end
       end
+
+      context "with optional thread" do
+        it "sends the message to the Web API without thread_ts" do
+          expect(api).to receive(:send_messages).with(private_message_source.room, ['foo'], { thread_ts: nil })
+
+          subject.send_messages(private_message_source, ['foo'])
+        end
+      end
     end
   end
 

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -73,7 +73,7 @@ describe Lita::Adapters::Slack, lita: true do
     end
 
     describe "via the Web API, retrieving the roster for a group/mpim channel" do
-      let(:room_source) { Lita::Source.new(room: 'G024BE91L') }
+      let(:room_source) { Lita::Adapters::Slack::SlackSource.new(room: 'G024BE91L') }
       let(:response) do
         {
           ok: true,
@@ -95,7 +95,7 @@ describe Lita::Adapters::Slack, lita: true do
     end
 
     describe "via the Web API, retrieving the roster for an im channel" do
-      let(:room_source) { Lita::Source.new(room: 'D024BFF1M') }
+      let(:room_source) { Lita::Adapters::Slack::SlackSource.new(room: 'D024BFF1M') }
       let(:response) do
         {
           ok: true,
@@ -117,7 +117,7 @@ describe Lita::Adapters::Slack, lita: true do
   end
 
   describe "#send_messages" do
-    let(:room_source) { Lita::Source.new(room: 'C024BE91L') }
+    let(:room_source) { Lita::Adapters::Slack::SlackSource.new(room: 'C024BE91L') }
     let(:user) { Lita::User.new('U023BECGF') }
     let(:user_source) { Lita::Source.new(user: user) }
     let(:private_message_source) do
@@ -133,9 +133,19 @@ describe Lita::Adapters::Slack, lita: true do
 
       it "does not send via the RTM api" do
         expect(rtm_connection).to_not receive(:send_messages)
-        expect(api).to receive(:send_messages).with(room_source.room, ['foo'])
+        expect(api).to receive(:send_messages).with(room_source.room, ['foo'], { thread_ts: nil })
 
         subject.send_messages(room_source, ['foo'])
+      end
+
+      context "when thread is set" do
+        let(:room_source) { Lita::Adapters::Slack::SlackSource.new(room: 'C024BE91L', thread: '12345.67890') }
+
+        it "sends the message to the Web API with thread_ts" do
+          expect(api).to receive(:send_messages).with(room_source.room, ['foo'], { thread_ts: '12345.67890' })
+
+          subject.send_messages(room_source, ['foo'])
+        end
       end
     end
   end

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -150,7 +150,7 @@ describe Lita::Adapters::Slack, lita: true do
 
       context "with optional thread" do
         it "sends the message to the Web API without thread_ts" do
-          expect(api).to receive(:send_messages).with(private_message_source.room, ['foo'], { thread_ts: nil })
+          expect(api).to receive(:send_messages).with(private_message_source.room, ['foo'])
 
           subject.send_messages(private_message_source, ['foo'])
         end

--- a/spec/lita/adapters/slack_spec.rb
+++ b/spec/lita/adapters/slack_spec.rb
@@ -155,6 +155,14 @@ describe Lita::Adapters::Slack, lita: true do
           subject.send_messages(private_message_source, ['foo'])
         end
       end
+
+      context "with user source" do
+        it "sends direct message to the Web API" do
+          expect(api).to receive(:send_messages).with(user_source.user.id, ['foo'])
+
+          subject.send_messages(user_source, ['foo'])
+        end
+      end
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,7 +6,7 @@ SimpleCov.formatters = [
 ]
 SimpleCov.start { add_filter "/spec/" }
 
-require "lita-slack"
+require_relative "../lib/lita-slack"
 require "lita/rspec"
 
 require "pry"


### PR DESCRIPTION
Updated code to use the new user lookup API. Related to #142 and you are strongly advised to merge this as well as the Slack API changes mean old user code no longer works.